### PR TITLE
Use specificity root_default for files without a specificity folder.

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -170,7 +170,7 @@ module Ridley::Chef
       case category
       when :files, :templates
         relpath = target.relative_path_from(path).to_s
-        relpath.slice(/(.+)\/(.+)\/.+/, 2)
+        relpath.slice(/(.+)\/(.+)\/.+/, 2) || 'root_default'
       else
         'default'
       end

--- a/spec/unit/ridley/chef/cookbook_spec.rb
+++ b/spec/unit/ridley/chef/cookbook_spec.rb
@@ -261,6 +261,45 @@ describe Ridley::Chef::Cookbook do
     end
   end
 
+  describe "#file_specificity" do
+    let(:category) { :templates }
+    let(:relpath) { 'default.rb' }
+    let(:file) { subject.path.join(category.to_s, relpath) }
+    before(:each) { @specificity = subject.file_specificity(category, file) }
+
+    context "given a recipe file" do
+      let(:category) { :recipes }
+
+      it "has a specificity of 'default'" do
+        @specificity.should eql("default")
+      end
+    end
+
+    context "given a template 'default/config.erb'" do
+      let(:relpath) { 'default/config.erb' }
+
+      it "has a specificity of 'default'" do
+        @specificity.should eql("default")
+      end
+    end
+
+    context "given a template 'centos/config.erb'" do
+      let(:relpath) { 'centos/config.erb' }
+
+      it "has a specificity of 'centos'" do
+        @specificity.should eql("centos")
+      end
+    end
+
+    context "given a template 'config.erb'" do
+      let(:relpath) { 'config.erb' }
+
+      it "has a specificity of 'root_default'" do
+        @specificity.should eql("root_default")
+      end
+    end
+  end
+
   describe "#to_hash" do
     subject { cookbook.to_hash }
 


### PR DESCRIPTION
This is things like files/foo.txt or templates/config.erb, added in
Chef 12. Also adds unit tests for Cookbook#file_specificity.

Currently Ridley sends `nil` which is rejected as invalid by Chef Server.