### PR TITLE
Make specs RSpec 3 compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 group :test do
   gem 'thor'
   gem 'rake', '>= 0.9.2.2'
-  gem 'rspec', '~> 2.14.0'
+  gem 'rspec', '~> 3.0'
   gem 'fuubar'
   gem 'json_spec'
   gem 'webmock'

--- a/spec/acceptance/client_resource_spec.rb
+++ b/spec/acceptance/client_resource_spec.rb
@@ -11,30 +11,30 @@ describe "Client API operations", type: "acceptance" do
       before { chef_client("reset", admin: false) }
 
       it "returns a ClientObject" do
-        connection.client.find("reset").should be_a(Ridley::ClientObject)
+        expect(connection.client.find("reset")).to be_a(Ridley::ClientObject)
       end
     end
 
     context "when the server does not have the client" do
       it "returns a nil value" do
-        connection.client.find("not_there").should be_nil
+        expect(connection.client.find("not_there")).to be_nil
       end
     end
   end
 
   describe "creating a client" do
     it "returns a Ridley::ClientObject" do
-      connection.client.create(name: "reset").should be_a(Ridley::ClientObject)
+      expect(connection.client.create(name: "reset")).to be_a(Ridley::ClientObject)
     end
 
     it "adds a client to the chef server" do
       old = connection.client.all.length
       connection.client.create(name: "reset")
-      connection.client.all.should have(old + 1).items
+      expect(connection.client.all.size).to eq(old + 1)
     end
 
     it "has a value for #private_key" do
-      connection.client.create(name: "reset").private_key.should_not be_nil
+      expect(connection.client.create(name: "reset").private_key).not_to be_nil
     end
   end
 
@@ -42,13 +42,13 @@ describe "Client API operations", type: "acceptance" do
     before { chef_client("reset", admin: false) }
 
     it "returns a Ridley::ClientObject object" do
-      connection.client.delete("reset").should be_a(Ridley::ClientObject)
+      expect(connection.client.delete("reset")).to be_a(Ridley::ClientObject)
     end
 
     it "removes the client from the server" do
       connection.client.delete("reset")
 
-      connection.client.find("reset").should be_nil
+      expect(connection.client.find("reset")).to be_nil
     end
   end
 
@@ -59,12 +59,12 @@ describe "Client API operations", type: "acceptance" do
     end
 
     it "returns an array of Ridley::ClientObject objects" do
-      connection.client.delete_all.should each be_a(Ridley::ClientObject)
+      expect(connection.client.delete_all).to each be_a(Ridley::ClientObject)
     end
 
     it "deletes all clients from the remote" do
       connection.client.delete_all
-      connection.client.all.should have(0).clients
+      expect(connection.client.all.size).to eq(0)
     end
   end
 
@@ -75,11 +75,11 @@ describe "Client API operations", type: "acceptance" do
     end
 
     it "returns an array of Ridley::ClientObject objects" do
-      connection.client.all.should each be_a(Ridley::ClientObject)
+      expect(connection.client.all).to each be_a(Ridley::ClientObject)
     end
 
     it "returns all of the clients on the server" do
-      connection.client.all.should have(4).items
+      expect(connection.client.all.size).to eq(4)
     end
   end
 
@@ -87,7 +87,7 @@ describe "Client API operations", type: "acceptance" do
     before { chef_client("reset", admin: false) }
 
     it "returns a Ridley::ClientObject object with a value for #private_key" do
-      connection.client.regenerate_key("reset").private_key.should match(/^-----BEGIN RSA PRIVATE KEY-----/)
+      expect(connection.client.regenerate_key("reset").private_key).to match(/^-----BEGIN RSA PRIVATE KEY-----/)
     end
   end
 end

--- a/spec/acceptance/cookbook_resource_spec.rb
+++ b/spec/acceptance/cookbook_resource_spec.rb
@@ -18,7 +18,7 @@ describe "Client API operations", type: "acceptance" do
       before { subject.download(name, version, destination) }
 
       it "downloads the cookbook to the destination" do
-        expect(File.exist?(destination.join("metadata.json"))).to be_true
+        expect(File.exist?(destination.join("metadata.json"))).to be_truthy
       end
     end
   end
@@ -30,23 +30,23 @@ describe "Client API operations", type: "acceptance" do
       subject.upload(path)
       cookbook = subject.find("example_cookbook", "0.1.0")
 
-      cookbook.attributes.should have(1).item
-      cookbook.definitions.should have(1).item
-      cookbook.files.should have(2).items
-      cookbook.libraries.should have(1).item
-      cookbook.providers.should have(1).item
-      cookbook.recipes.should have(1).item
-      cookbook.resources.should have(1).item
-      cookbook.templates.should have(1).item
-      cookbook.root_files.should have(1).items
+      expect(cookbook.attributes.size).to eq(1)
+      expect(cookbook.definitions.size).to eq(1)
+      expect(cookbook.files.size).to eq(2)
+      expect(cookbook.libraries.size).to eq(1)
+      expect(cookbook.providers.size).to eq(1)
+      expect(cookbook.recipes.size).to eq(1)
+      expect(cookbook.resources.size).to eq(1)
+      expect(cookbook.templates.size).to eq(1)
+      expect(cookbook.root_files.size).to eq(1)
     end
 
     it "does not contain a raw metadata.rb but does contain a compiled metadata.json" do
       subject.upload(path)
       cookbook = subject.find("example_cookbook", "0.1.0")
 
-      expect(cookbook.root_files.any? { |f| f[:name] == "metadata.json" }).to be_true
-      expect(cookbook.root_files.any? { |f| f[:name] == "metadata.rb" }).to be_false
+      expect(cookbook.root_files.any? { |f| f[:name] == "metadata.json" }).to be_truthy
+      expect(cookbook.root_files.any? { |f| f[:name] == "metadata.rb" }).to be_falsey
     end
   end
 
@@ -60,9 +60,9 @@ describe "Client API operations", type: "acceptance" do
 
     it "returns all of the cookbooks on the server" do
       all_cookbooks = subject.all
-      expect(all_cookbooks).to have(2).items
-      expect(all_cookbooks["ruby"]).to have(2).items
-      expect(all_cookbooks["elixir"]).to have(2).items
+      expect(all_cookbooks.size).to eq(2)
+      expect(all_cookbooks["ruby"].size).to eq(2)
+      expect(all_cookbooks["elixir"].size).to eq(2)
     end
   end
 end

--- a/spec/acceptance/data_bag_item_resource_spec.rb
+++ b/spec/acceptance/data_bag_item_resource_spec.rb
@@ -14,7 +14,7 @@ describe "DataBag API operations", type: "acceptance" do
   describe "listing data bag items" do
     context "when the data bag has no items" do
       it "returns an empty array" do
-        data_bag.item.all.should have(0).items
+        expect(data_bag.item.all.size).to eq(0)
       end
     end
 
@@ -25,7 +25,7 @@ describe "DataBag API operations", type: "acceptance" do
       end
 
       it "returns an array with each item" do
-        data_bag.item.all.should have(2).items
+        expect(data_bag.item.all.size).to eq(2)
       end
     end
   end
@@ -34,7 +34,7 @@ describe "DataBag API operations", type: "acceptance" do
     it "adds a data bag item to the collection of data bag items" do
       data_bag.item.create(id: "appconfig", host: "host.local", port: 80, admin: false, servers: ["one"])
 
-      data_bag.item.all.should have(1).item
+      expect(data_bag.item.all.size).to eq(1)
     end
 
     context "when an 'id' field is missing" do
@@ -59,7 +59,7 @@ describe "DataBag API operations", type: "acceptance" do
       }
       data_bag.item.create(attributes)
 
-      data_bag.item.find("appconfig").to_hash.should eql(attributes)
+      expect(data_bag.item.find("appconfig").to_hash).to eql(attributes)
     end
   end
 
@@ -76,14 +76,14 @@ describe "DataBag API operations", type: "acceptance" do
     it "returns the deleted data bag item" do
       dbi = data_bag.item.delete(attributes["id"])
 
-      dbi.should be_a(Ridley::DataBagItemObject)
-      dbi.attributes.should eql(attributes)
+      expect(dbi).to be_a(Ridley::DataBagItemObject)
+      expect(dbi.attributes).to eql(attributes)
     end
 
     it "deletes the data bag item from the server" do
       data_bag.item.delete(attributes["id"])
 
-      data_bag.item.find(attributes["id"]).should be_nil
+      expect(data_bag.item.find(attributes["id"])).to be_nil
     end
   end
 
@@ -94,13 +94,13 @@ describe "DataBag API operations", type: "acceptance" do
     end
 
     it "returns the array of deleted data bag items" do
-      data_bag.item.delete_all.should each be_a(Ridley::DataBagItemObject)
+      expect(data_bag.item.delete_all).to each be_a(Ridley::DataBagItemObject)
     end
 
     it "removes all data bag items from the data bag" do
       data_bag.item.delete_all
 
-      data_bag.item.all.should have(0).items
+      expect(data_bag.item.all.size).to eq(0)
     end
   end
 
@@ -110,7 +110,7 @@ describe "DataBag API operations", type: "acceptance" do
     it "returns the updated data bag item" do
       dbi = data_bag.item.update(id: "one", name: "brooke")
 
-      dbi[:name].should eql("brooke")
+      expect(dbi[:name]).to eql("brooke")
     end
   end
 
@@ -120,14 +120,14 @@ describe "DataBag API operations", type: "acceptance" do
 
       it "returns true if successful" do
         dbi[:name] = "brooke"
-        dbi.save.should be_true
+        expect(dbi.save).to be_truthy
       end
 
       it "creates a new data bag item on the remote" do
         dbi[:name] = "brooke"
         dbi.save
 
-        data_bag.item.all.should have(1).item
+        expect(data_bag.item.all.size).to eq(1)
       end
     end
 
@@ -136,7 +136,7 @@ describe "DataBag API operations", type: "acceptance" do
         dbi = data_bag.item.new
 
         dbi.attributes = { id: "not-there", name: "brooke" }
-        dbi.save.should be_true
+        expect(dbi.save).to be_truthy
       end
 
       it "creates a new data bag item on the remote" do
@@ -144,7 +144,7 @@ describe "DataBag API operations", type: "acceptance" do
         dbi.attributes = { id: "not-there", name: "brooke" }
         dbi.save
 
-        data_bag.item.all.should have(1).item
+        expect(data_bag.item.all.size).to eq(1)
       end
     end
   end

--- a/spec/acceptance/data_bag_resource_spec.rb
+++ b/spec/acceptance/data_bag_resource_spec.rb
@@ -9,7 +9,7 @@ describe "DataBag API operations", type: "acceptance" do
   describe "listing data bags" do
     context "when no data bags exist" do
       it "returns an empty array" do
-        connection.data_bag.all.should have(0).items
+        expect(connection.data_bag.all.size).to eq(0)
       end
     end
 
@@ -20,18 +20,18 @@ describe "DataBag API operations", type: "acceptance" do
       end
 
       it "returns an array of data bags" do
-        connection.data_bag.all.should each be_a(Ridley::DataBagObject)
+        expect(connection.data_bag.all).to each be_a(Ridley::DataBagObject)
       end
 
       it "returns all of the data bags on the server" do
-        connection.data_bag.all.should have(2).items
+        expect(connection.data_bag.all.size).to eq(2)
       end
     end
   end
 
   describe "creating a data bag" do
     it "returns a Ridley::DataBagObject" do
-      connection.data_bag.create(name: "ridley-one").should be_a(Ridley::DataBagObject)
+      expect(connection.data_bag.create(name: "ridley-one")).to be_a(Ridley::DataBagObject)
     end
   end
 end

--- a/spec/acceptance/environment_resource_spec.rb
+++ b/spec/acceptance/environment_resource_spec.rb
@@ -10,7 +10,7 @@ describe "Environment API operations", type: "acceptance" do
     before { chef_environment("ridley-test-env") }
 
     it "returns a valid Ridley::EnvironmentObject object" do
-      connection.environment.find("ridley-test-env").should be_a(Ridley::EnvironmentObject)
+      expect(connection.environment.find("ridley-test-env")).to be_a(Ridley::EnvironmentObject)
     end
   end
 
@@ -18,13 +18,13 @@ describe "Environment API operations", type: "acceptance" do
     it "returns a valid Ridley::EnvironmentObject object" do
       obj = connection.environment.create(name: "ridley-test-env", description: "a testing env for ridley")
 
-      obj.should be_a(Ridley::EnvironmentObject)
+      expect(obj).to be_a(Ridley::EnvironmentObject)
     end
 
     it "adds an environment to the chef server" do
       old = connection.environment.all.length
       connection.environment.create(name: "ridley")
-      connection.environment.all.should have(old + 1).item
+      expect(connection.environment.all.size).to eq(old + 1)
     end
   end
 
@@ -32,19 +32,19 @@ describe "Environment API operations", type: "acceptance" do
     before { chef_environment("ridley-env") }
 
     it "returns a Ridley::EnvironmentObject object" do
-      connection.environment.delete("ridley-env").should be_a(Ridley::EnvironmentObject)
+      expect(connection.environment.delete("ridley-env")).to be_a(Ridley::EnvironmentObject)
     end
 
     it "removes the environment from the server" do
       connection.environment.delete("ridley-env")
 
-      connection.environment.find("ridley-env").should be_nil
+      expect(connection.environment.find("ridley-env")).to be_nil
     end
 
     it "raises Ridley::Errors::HTTPMethodNotAllowed when attempting to delete the '_default' environment" do
-      lambda {
+      expect {
         connection.environment.delete("_default")
-      }.should raise_error(Ridley::Errors::HTTPMethodNotAllowed)
+      }.to raise_error(Ridley::Errors::HTTPMethodNotAllowed)
     end
   end
 
@@ -55,19 +55,19 @@ describe "Environment API operations", type: "acceptance" do
     end
 
     it "returns an array of Ridley::EnvironmentObject objects" do
-      connection.environment.delete_all.should each be_a(Ridley::EnvironmentObject)
+      expect(connection.environment.delete_all).to each be_a(Ridley::EnvironmentObject)
     end
 
     it "deletes all environments but '_default' from the remote" do
       connection.environment.delete_all
 
-      connection.environment.all.should have(1).item
+      expect(connection.environment.all.size).to eq(1)
     end
   end
 
   describe "listing all environments" do
     it "should return an array of Ridley::EnvironmentObject objects" do
-      connection.environment.all.should each be_a(Ridley::EnvironmentObject)
+      expect(connection.environment.all).to each be_a(Ridley::EnvironmentObject)
     end
   end
 
@@ -79,7 +79,7 @@ describe "Environment API operations", type: "acceptance" do
       target.description = description = "ridley testing environment"
 
       connection.environment.update(target)
-      target.reload.description.should eql(description)
+      expect(target.reload.description).to eql(description)
     end
 
     it "saves a new set of 'default_attributes'" do
@@ -92,7 +92,7 @@ describe "Environment API operations", type: "acceptance" do
 
       connection.environment.update(target)
       obj = connection.environment.find(target)
-      obj.default_attributes.should eql(default_attributes)
+      expect(obj.default_attributes).to eql(default_attributes)
     end
 
     it "saves a new set of 'override_attributes'" do
@@ -105,7 +105,7 @@ describe "Environment API operations", type: "acceptance" do
 
       connection.environment.update(target)
       obj = connection.environment.find(target)
-      obj.override_attributes.should eql(override_attributes)
+      expect(obj.override_attributes).to eql(override_attributes)
     end
 
     it "saves a new set of 'cookbook_versions'" do
@@ -116,7 +116,7 @@ describe "Environment API operations", type: "acceptance" do
 
       connection.environment.update(target)
       obj = connection.environment.find(target)
-      obj.cookbook_versions.should eql(cookbook_versions)
+      expect(obj.cookbook_versions).to eql(cookbook_versions)
     end
   end
 end

--- a/spec/acceptance/node_resource_spec.rb
+++ b/spec/acceptance/node_resource_spec.rb
@@ -11,7 +11,7 @@ describe "Node API operations", type: "acceptance" do
     before { chef_node(node_name) }
 
     it "returns a Ridley::NodeObject" do
-      connection.node.find(node_name).should be_a(Ridley::NodeObject)
+      expect(connection.node.find(node_name)).to be_a(Ridley::NodeObject)
     end
   end
 
@@ -19,13 +19,13 @@ describe "Node API operations", type: "acceptance" do
     let(:node_name) { "ridley.localhost" }
 
     it "returns a new Ridley::NodeObject object" do
-      connection.node.create(name: node_name).should be_a(Ridley::NodeObject)
+      expect(connection.node.create(name: node_name)).to be_a(Ridley::NodeObject)
     end
 
     it "adds a new node to the server" do
       connection.node.create(name: node_name)
 
-      connection.node.all.should have(1).node
+      expect(connection.node.all.size).to eq(1)
     end
   end
 
@@ -34,13 +34,13 @@ describe "Node API operations", type: "acceptance" do
     before { chef_node(node_name) }
 
     it "returns a Ridley::NodeObject" do
-      connection.node.delete(node_name).should be_a(Ridley::NodeObject)
+      expect(connection.node.delete(node_name)).to be_a(Ridley::NodeObject)
     end
 
     it "removes the node from the server" do
       connection.node.delete(node_name)
 
-      connection.node.find(node_name).should be_nil
+      expect(connection.node.find(node_name)).to be_nil
     end
   end
 
@@ -53,7 +53,7 @@ describe "Node API operations", type: "acceptance" do
     it "deletes all nodes from the remote server" do
       connection.node.delete_all
 
-      connection.node.all.should have(0).nodes
+      expect(connection.node.all.size).to eq(0)
     end
   end
 
@@ -66,8 +66,8 @@ describe "Node API operations", type: "acceptance" do
     it "returns an array of Ridley::NodeObject" do
       obj = connection.node.all
 
-      obj.should each be_a(Ridley::NodeObject)
-      obj.should have(2).nodes
+      expect(obj).to each be_a(Ridley::NodeObject)
+      expect(obj.size).to eq(2)
     end
   end
 
@@ -77,7 +77,7 @@ describe "Node API operations", type: "acceptance" do
     let(:target) { connection.node.find(node_name) }
 
     it "returns the updated node" do
-      connection.node.update(target).should eql(target)
+      expect(connection.node.update(target)).to eql(target)
     end
 
     it "saves a new set of 'normal' attributes" do
@@ -91,7 +91,7 @@ describe "Node API operations", type: "acceptance" do
       connection.node.update(target)
       obj = connection.node.find(target)
 
-      obj.normal.should eql(normal)
+      expect(obj.normal).to eql(normal)
     end
 
     it "saves a new set of 'default' attributes" do
@@ -105,7 +105,7 @@ describe "Node API operations", type: "acceptance" do
       connection.node.update(target)
       obj = connection.node.find(target)
 
-      obj.default.should eql(defaults)
+      expect(obj.default).to eql(defaults)
     end
 
     it "saves a new set of 'automatic' attributes" do
@@ -119,7 +119,7 @@ describe "Node API operations", type: "acceptance" do
       connection.node.update(target)
       obj = connection.node.find(target)
 
-      obj.automatic.should eql(automatics)
+      expect(obj.automatic).to eql(automatics)
     end
 
     it "saves a new set of 'override' attributes" do
@@ -133,7 +133,7 @@ describe "Node API operations", type: "acceptance" do
       connection.node.update(target)
       obj = connection.node.find(target)
 
-      obj.override.should eql(overrides)
+      expect(obj.override).to eql(overrides)
     end
 
     it "places a node in a new 'chef_environment'" do
@@ -142,7 +142,7 @@ describe "Node API operations", type: "acceptance" do
       connection.node.update(target)
       obj = connection.node.find(target)
 
-      obj.chef_environment.should eql(environment)
+      expect(obj.chef_environment).to eql(environment)
     end
 
     it "saves a new 'run_list' for the node" do
@@ -151,7 +151,7 @@ describe "Node API operations", type: "acceptance" do
       connection.node.update(target)
       obj = connection.node.find(target)
 
-      obj.run_list.should eql(run_list)
+      expect(obj.run_list).to eql(run_list)
     end
   end
 end

--- a/spec/acceptance/role_resource_spec.rb
+++ b/spec/acceptance/role_resource_spec.rb
@@ -11,7 +11,7 @@ describe "Role API operations", type: "acceptance" do
     before { chef_role(role_name) }
 
     it "returns a Ridley::RoleObject" do
-      connection.role.find(role_name).should be_a(Ridley::RoleObject)
+      expect(connection.role.find(role_name)).to be_a(Ridley::RoleObject)
     end
   end
 
@@ -19,12 +19,12 @@ describe "Role API operations", type: "acceptance" do
     let(:role_name) { "ridley-role" }
 
     it "returns a new Ridley::RoleObject" do
-      connection.role.create(name: role_name).should be_a(Ridley::RoleObject)
+      expect(connection.role.create(name: role_name)).to be_a(Ridley::RoleObject)
     end
 
     it "adds a new role to the server" do
       connection.role.create(name: role_name)
-      connection.role.all.should have(1).role
+      expect(connection.role.all.size).to eq(1)
     end
   end
 
@@ -33,13 +33,13 @@ describe "Role API operations", type: "acceptance" do
     before { chef_role(role_name) }
 
     it "returns the deleted Ridley::RoleObject resource" do
-      connection.role.delete(role_name).should be_a(Ridley::RoleObject)
+      expect(connection.role.delete(role_name)).to be_a(Ridley::RoleObject)
     end
 
     it "removes the role from the server" do
       connection.role.delete(role_name)
 
-      connection.role.find(role_name).should be_nil
+      expect(connection.role.find(role_name)).to be_nil
     end
   end
 
@@ -52,7 +52,7 @@ describe "Role API operations", type: "acceptance" do
     it "deletes all nodes from the remote server" do
       connection.role.delete_all
 
-      connection.role.all.should have(0).roles
+      expect(connection.role.all.size).to eq(0)
     end
   end
 
@@ -65,8 +65,8 @@ describe "Role API operations", type: "acceptance" do
     it "should return an array of Ridley::RoleObject" do
       obj = connection.role.all
 
-      obj.should have(2).roles
-      obj.should each be_a(Ridley::RoleObject)
+      expect(obj.size).to eq(2)
+      expect(obj).to each be_a(Ridley::RoleObject)
     end
   end
 
@@ -76,7 +76,7 @@ describe "Role API operations", type: "acceptance" do
     let(:target) { connection.role.find(role_name) }
 
     it "returns an updated Ridley::RoleObject object" do
-      connection.role.update(target).should eql(target)
+      expect(connection.role.update(target)).to eql(target)
     end
 
     it "saves a new run_list" do
@@ -85,7 +85,7 @@ describe "Role API operations", type: "acceptance" do
       connection.role.update(target)
       obj = connection.role.find(target)
 
-      obj.run_list.should eql(run_list)
+      expect(obj.run_list).to eql(run_list)
     end
 
     it "saves a new env_run_lists" do
@@ -97,7 +97,7 @@ describe "Role API operations", type: "acceptance" do
       connection.role.update(target)
       obj = connection.role.find(target)
 
-      obj.env_run_lists.should eql(env_run_lists)
+      expect(obj.env_run_lists).to eql(env_run_lists)
     end
 
     it "saves a new description" do
@@ -106,7 +106,7 @@ describe "Role API operations", type: "acceptance" do
       connection.role.update(target)
       obj = connection.role.find(target)
 
-      obj.description.should eql(description)
+      expect(obj.description).to eql(description)
     end
 
     it "saves a new default_attributes" do
@@ -120,7 +120,7 @@ describe "Role API operations", type: "acceptance" do
       connection.role.update(target)
       obj = connection.role.find(target)
 
-      obj.default_attributes.should eql(defaults)
+      expect(obj.default_attributes).to eql(defaults)
     end
 
     it "saves a new override_attributes" do
@@ -134,7 +134,7 @@ describe "Role API operations", type: "acceptance" do
       connection.role.update(target)
       obj = connection.role.find(target)
 
-      obj.override_attributes.should eql(overrides)
+      expect(obj.override_attributes).to eql(overrides)
     end
   end
 end

--- a/spec/acceptance/sandbox_resource_spec.rb
+++ b/spec/acceptance/sandbox_resource_spec.rb
@@ -15,15 +15,15 @@ describe "Sandbox API operations", type: "acceptance" do
 
   describe "creating a new sandbox" do
     it "returns an instance of Ridley::SandboxObject" do
-      connection.sandbox.create(checksums).should be_a(Ridley::SandboxObject)
+      expect(connection.sandbox.create(checksums)).to be_a(Ridley::SandboxObject)
     end
 
     it "contains a value for sandbox_id" do
-      connection.sandbox.create(checksums).sandbox_id.should_not be_nil
+      expect(connection.sandbox.create(checksums).sandbox_id).not_to be_nil
     end
 
     it "returns an instance with the same amount of checksums given to create" do
-      connection.sandbox.create(checksums).checksums.should have(2).items
+      expect(connection.sandbox.create(checksums).checksums.size).to eq(2)
     end
   end
 end

--- a/spec/acceptance/search_resource_spec.rb
+++ b/spec/acceptance/search_resource_spec.rb
@@ -10,18 +10,18 @@ describe "Search API operations", type: "acceptance" do
     it "returns an array of indexes" do
       indexes = connection.search_indexes
 
-      indexes.should include("role")
-      indexes.should include("node")
-      indexes.should include("client")
-      indexes.should include("environment")
+      expect(indexes).to include("role")
+      expect(indexes).to include("node")
+      expect(indexes).to include("client")
+      expect(indexes).to include("environment")
     end
   end
 
   describe "searching an index that doesn't exist" do
     it "it raises a Ridley::Errors::HTTPNotFound error" do
-      lambda {
+      expect {
         connection.search(:notthere)
-      }.should raise_error(Ridley::Errors::HTTPNotFound)
+      }.to raise_error(Ridley::Errors::HTTPNotFound)
     end
   end
 end

--- a/spec/acceptance/user_resource_spec.rb
+++ b/spec/acceptance/user_resource_spec.rb
@@ -11,30 +11,30 @@ describe "User API operations", type: "wip" do
       before { chef_user("reset", admin: false) }
 
       it "returns a UserObject" do
-        connection.user.find("reset").should be_a(Ridley::UserObject)
+        expect(connection.user.find("reset")).to be_a(Ridley::UserObject)
       end
     end
 
     context "when the server does not have the user" do
       it "returns a nil value" do
-        connection.user.find("not_there").should be_nil
+        expect(connection.user.find("not_there")).to be_nil
       end
     end
   end
 
   describe "creating a user" do
     it "returns a Ridley::UserObject" do
-      connection.user.create(name: "reset").should be_a(Ridley::UserObject)
+      expect(connection.user.create(name: "reset")).to be_a(Ridley::UserObject)
     end
 
     it "adds a user to the chef server" do
       old = connection.user.all.length
       connection.user.create(name: "reset")
-      connection.user.all.should have(old + 1).items
+      expect(connection.user.all.size).to eq(old + 1)
     end
 
     it "has a value for #private_key" do
-      connection.user.create(name: "reset").private_key.should_not be_nil
+      expect(connection.user.create(name: "reset").private_key).not_to be_nil
     end
   end
 
@@ -42,13 +42,13 @@ describe "User API operations", type: "wip" do
     before { chef_user("reset", admin: false) }
 
     it "returns a Ridley::UserObject object" do
-      connection.user.delete("reset").should be_a(Ridley::UserObject)
+      expect(connection.user.delete("reset")).to be_a(Ridley::UserObject)
     end
 
     it "removes the user from the server" do
       connection.user.delete("reset")
 
-      connection.user.find("reset").should be_nil
+      expect(connection.user.find("reset")).to be_nil
     end
   end
 
@@ -59,12 +59,12 @@ describe "User API operations", type: "wip" do
     end
 
     it "returns an array of Ridley::UserObject objects" do
-      connection.user.delete_all.should each be_a(Ridley::UserObject)
+      expect(connection.user.delete_all).to each be_a(Ridley::UserObject)
     end
 
     it "deletes all users from the remote" do
       connection.user.delete_all
-      connection.user.all.should have(0).users
+      expect(connection.user.all.size).to eq(0)
     end
   end
 
@@ -75,11 +75,11 @@ describe "User API operations", type: "wip" do
     end
 
     it "returns an array of Ridley::UserObject objects" do
-      connection.user.all.should each be_a(Ridley::UserObject)
+      expect(connection.user.all).to each be_a(Ridley::UserObject)
     end
 
     it "returns all of the users on the server" do
-      connection.user.all.should have(3).items
+      expect(connection.user.all.size).to eq(3)
     end
   end
 
@@ -87,7 +87,7 @@ describe "User API operations", type: "wip" do
     before { chef_user("reset", admin: false) }
 
     it "returns a Ridley::UserObject object with a value for #private_key" do
-      connection.user.regenerate_key("reset").private_key.should match(/^-----BEGIN RSA PRIVATE KEY-----/)
+      expect(connection.user.regenerate_key("reset").private_key).to match(/^-----BEGIN RSA PRIVATE KEY-----/)
     end
   end
 
@@ -95,20 +95,20 @@ describe "User API operations", type: "wip" do
     before { chef_user('reset', password: 'swordfish') }
 
     it "returns true when given valid username & password" do
-      expect(connection.user.authenticate('reset', 'swordfish')).to be_true
+      expect(connection.user.authenticate('reset', 'swordfish')).to be_truthy
     end
 
     it "returns false when given valid username & invalid password" do
-      expect(connection.user.authenticate('reset', "not a swordfish")).to be_false
+      expect(connection.user.authenticate('reset', "not a swordfish")).to be_falsey
     end
 
     it "returns false when given invalid username & valid password" do
-      expect(connection.user.authenticate("someone-else", 'swordfish')).to be_false
+      expect(connection.user.authenticate("someone-else", 'swordfish')).to be_falsey
     end
 
     it "works also on a User object level" do
-      expect(connection.user.find('reset').authenticate('swordfish')).to be_true
-      expect(connection.user.find('reset').authenticate('not a swordfish')).to be_false
+      expect(connection.user.find('reset').authenticate('swordfish')).to be_truthy
+      expect(connection.user.find('reset').authenticate('not a swordfish')).to be_falsey
     end
   end
 
@@ -117,14 +117,14 @@ describe "User API operations", type: "wip" do
     subject { connection.user.find('reset') }
 
     it "changes the password with which user can authenticate" do
-      expect(subject.authenticate('swordfish')).to be_true
-      expect(subject.authenticate('salmon')).to be_false
+      expect(subject.authenticate('swordfish')).to be_truthy
+      expect(subject.authenticate('salmon')).to be_falsey
 
       subject.password = 'salmon'
       subject.save
 
-      expect(subject.authenticate('swordfish')).to be_false
-      expect(subject.authenticate('salmon')).to be_true
+      expect(subject.authenticate('swordfish')).to be_falsey
+      expect(subject.authenticate('salmon')).to be_truthy
     end
   end
 end

--- a/spec/support/each_matcher.rb
+++ b/spec/support/each_matcher.rb
@@ -2,11 +2,11 @@ RSpec::Matchers.define :each do |check|
   match do |actual|
     actual.each_with_index do |index, o|
       @object = o
-      index.should check
+      expect(index).to check
     end
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "at[#{@object}] #{check.failure_message_for_should}"
   end
 end

--- a/spec/support/filepath_matchers.rb
+++ b/spec/support/filepath_matchers.rb
@@ -9,11 +9,11 @@ RSpec::Matchers.define :be_relative_path do
     end
   end
 
-  failure_message_for_should do |given|
+  failure_message do |given|
     "Expected '#{given}' to be a relative path but got an absolute path."
   end
 
-  failure_message_for_should_not do |given|
+  failure_message_when_negated do |given|
     "Expected '#{given}' to not be a relative path but got an absolute path."
   end
 end

--- a/spec/support/shared_examples/ridley_resource.rb
+++ b/spec/support/shared_examples/ridley_resource.rb
@@ -9,8 +9,8 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
 
     describe "::all" do
       it "sends a get request for the class' resource_path using the given client" do
-        response.stub(:body) { Hash.new }
-        client.connection.should_receive(:get).with(subject.resource_path).and_return(response)
+        allow(response).to receive(:body) { Hash.new }
+        expect(client.connection).to receive(:get).with(subject.resource_path).and_return(response)
 
         subject.all(client)
       end
@@ -19,8 +19,8 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
     describe "::find" do
       it "sends a get request to the given client to the resource_path of the class for the given chef_id" do
         chef_id = "ridley_test"
-        response.stub(:body) { Hash.new }
-        client.connection.should_receive(:get).with("#{subject.resource_path}/#{chef_id}").and_return(response)
+        allow(response).to receive(:body) { Hash.new }
+        expect(client.connection).to receive(:get).with("#{subject.resource_path}/#{chef_id}").and_return(response)
 
         subject.find(client, chef_id)
       end
@@ -33,8 +33,8 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
           last_name: "winsor"
         }
 
-        response.stub(:body) { attrs }
-        client.connection.should_receive(:post).with(subject.resource_path, duck_type(:to_json)).and_return(response)
+        allow(response).to receive(:body) { attrs }
+        expect(client.connection).to receive(:post).with(subject.resource_path, duck_type(:to_json)).and_return(response)
 
         subject.create(client, attrs)
       end
@@ -42,17 +42,17 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
 
     describe "::delete" do
       it "sends a delete request to the given client using the includer's resource_path for the given string" do
-        response.stub(:body) { Hash.new }
-        client.connection.should_receive(:delete).with("#{subject.resource_path}/ridley-test").and_return(response)
+        allow(response).to receive(:body) { Hash.new }
+        expect(client.connection).to receive(:delete).with("#{subject.resource_path}/ridley-test").and_return(response)
 
         subject.delete(client, "ridley-test")
       end
 
       it "accepts an object that responds to 'chef_id'" do
         object = double("obj")
-        object.stub(:chef_id) { "hello" }
-        response.stub(:body) { Hash.new }
-        client.connection.should_receive(:delete).with("#{subject.resource_path}/#{object.chef_id}").and_return(response)
+        allow(object).to receive(:chef_id) { "hello" }
+        allow(response).to receive(:body) { Hash.new }
+        expect(client.connection).to receive(:delete).with("#{subject.resource_path}/#{object.chef_id}").and_return(response)
 
         subject.delete(client, object)
       end
@@ -60,17 +60,17 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
 
     describe "::delete_all" do
       it "sends a delete request for every object in the collection" do
-        pending
+        skip
       end
     end
 
     describe "::update" do
       it "sends a put request to the given client using the includer's resource_path with the given object" do
-        subject.stub(:chef_id) { :name }
+        allow(subject).to receive(:chef_id) { :name }
         subject.attribute(:name)
         object = subject.new(name: "hello")
-        response.stub(:body) { Hash.new }
-        client.connection.should_receive(:put).with("#{subject.resource_path}/#{object.chef_id}", duck_type(:to_json)).and_return(response)
+        allow(response).to receive(:body) { Hash.new }
+        expect(client.connection).to receive(:put).with("#{subject.resource_path}/#{object.chef_id}", duck_type(:to_json)).and_return(response)
 
         subject.update(client, object)
       end
@@ -81,12 +81,12 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
 
   describe "#save" do
     context "when the object is valid" do
-      before(:each) { subject.stub(:valid?).and_return(true) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(true) }
 
       it "sends a create message to the implementing class" do
         updated = double('updated')
-        updated.stub(:_attributes_).and_return(Hash.new)
-        subject.class.should_receive(:create).with(client, subject).and_return(updated)
+        allow(updated).to receive(:_attributes_).and_return(Hash.new)
+        expect(subject.class).to receive(:create).with(client, subject).and_return(updated)
 
         subject.save
       end
@@ -94,10 +94,10 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
       context "when there is an HTTPConflict" do
         it "sends the update message to self" do
           updated = double('updated')
-          updated.stub(:[]).and_return(Hash.new)
-          updated.stub(:_attributes_).and_return(Hash.new)
-          subject.class.should_receive(:create).and_raise(Ridley::Errors::HTTPConflict.new(updated))
-          subject.should_receive(:update).and_return(updated)
+          allow(updated).to receive(:[]).and_return(Hash.new)
+          allow(updated).to receive(:_attributes_).and_return(Hash.new)
+          expect(subject.class).to receive(:create).and_raise(Ridley::Errors::HTTPConflict.new(updated))
+          expect(subject).to receive(:update).and_return(updated)
 
           subject.save
         end
@@ -105,12 +105,12 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
     end
 
     context "when the object is invalid" do
-      before(:each) { subject.stub(:valid?).and_return(false) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(false) }
 
       it "raises an InvalidResource error" do
-        lambda {
+        expect {
           subject.save
-        }.should raise_error(Ridley::Errors::InvalidResource)
+        }.to raise_error(Ridley::Errors::InvalidResource)
       end
     end
   end
@@ -119,31 +119,31 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
     context "when the object is valid" do
       let(:updated) do
         updated = double('updated')
-        updated.stub(:[]).and_return(Hash.new)
-        updated.stub(:_attributes_).and_return(Hash.new)
+        allow(updated).to receive(:[]).and_return(Hash.new)
+        allow(updated).to receive(:_attributes_).and_return(Hash.new)
         updated
       end
 
-      before(:each) { subject.stub(:valid?).and_return(true) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(true) }
 
       it "sends an update message to the implementing class" do
-        subject.class.should_receive(:update).with(anything, subject).and_return(updated)
+        expect(subject.class).to receive(:update).with(anything, subject).and_return(updated)
         subject.update
       end
 
       it "returns true" do
-        subject.class.should_receive(:update).with(anything, subject).and_return(updated)
-        subject.update.should eql(true)
+        expect(subject.class).to receive(:update).with(anything, subject).and_return(updated)
+        expect(subject.update).to eql(true)
       end
     end
 
     context "when the object is invalid" do
-      before(:each) { subject.stub(:valid?).and_return(false) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(false) }
 
       it "raises an InvalidResource error" do
-        lambda {
+        expect {
           subject.update
-        }.should raise_error(Ridley::Errors::InvalidResource)
+        }.to raise_error(Ridley::Errors::InvalidResource)
       end
     end
   end
@@ -151,10 +151,10 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
   describe "#chef_id" do
     it "returns the value of the chef_id attribute" do
       subject.class.attribute(:name)
-      subject.class.stub(:chef_id) { :name }
+      allow(subject.class).to receive(:chef_id) { :name }
       subject.mass_assign(name: "reset")
 
-      subject.chef_id.should eql("reset")
+      expect(subject.chef_id).to eql("reset")
     end
   end
 
@@ -163,17 +163,17 @@ shared_examples_for "a Ridley Resource" do |resource_klass|
 
     before(:each) do
       subject.class.attribute(:fake_attribute)
-      subject.class.stub(:find).with(client, subject).and_return(updated_subject)
+      allow(subject.class).to receive(:find).with(client, subject).and_return(updated_subject)
     end
 
     it "returns itself" do
-      subject.reload.should eql(subject)
+      expect(subject.reload).to eql(subject)
     end
 
     it "sets the attributes of self to include those of the reloaded object" do
       subject.reload
 
-      subject.get_attribute(:fake_attribute).should eql("some_value")
+      expect(subject.get_attribute(:fake_attribute)).to eql("some_value")
     end
   end
 end

--- a/spec/unit/ridley/chef/cookbook/metadata_spec.rb
+++ b/spec/unit/ridley/chef/cookbook/metadata_spec.rb
@@ -17,36 +17,36 @@ describe Ridley::Chef::Cookbook::Metadata do
         :choice => [ "test1", "test2" ],
         :default => "test1"
       }
-      lambda {
+      expect {
         subject.attribute("test_cookbook/test", options)
-      }.should_not raise_error
+      }.not_to raise_error
   
       options = {
         :type => "boolean",
         :choice => [ true, false ],
         :default => true
       }
-      lambda {
+      expect {
         subject.attribute("test_cookbook/test", options)
-      }.should_not raise_error
+      }.not_to raise_error
 
       options = {
         :type => "numeric",
         :choice => [ 1337, 420 ],
         :default => 1337
       }
-      lambda {
+      expect {
         subject.attribute("test_cookbook/test", options)
-      }.should_not raise_error
+      }.not_to raise_error
 
       options = {
         :type => "numeric",
         :choice => [ true, "false" ],
         :default => false
       }
-      lambda {
+      expect {
         subject.attribute("test_cookbook/test", options)
-      }.should raise_error
+      }.to raise_error
     end
   end
 end

--- a/spec/unit/ridley/chef/cookbook/syntax_check_spec.rb
+++ b/spec/unit/ridley/chef/cookbook/syntax_check_spec.rb
@@ -12,7 +12,7 @@ describe Ridley::Chef::Cookbook::SyntaxCheck do
   subject { syntax_check }
 
   before(:each) do
-    subject.stub(:chefignore) { chefignore }
+    allow(subject).to receive(:chefignore) { chefignore }
   end
 
   describe "#ruby_files" do
@@ -55,7 +55,7 @@ describe Ridley::Chef::Cookbook::SyntaxCheck do
     it "checks if a file has already been validated" do
       valid_template_file = cookbook_dir.join("templates/default/temp.txt.erb").to_s
       subject.validated(valid_template_file)
-      expect(subject.validated?(valid_template_file)).to be_true
+      expect(subject.validated?(valid_template_file)).to be_truthy
     end
   end
 
@@ -63,7 +63,7 @@ describe Ridley::Chef::Cookbook::SyntaxCheck do
     let(:validated_files) { double('validated_files') }
 
     before(:each) do
-      subject.stub(:validated_files) { validated_files }
+      allow(subject).to receive(:validated_files) { validated_files }
     end
 
     it "records a file as validated" do
@@ -77,35 +77,35 @@ describe Ridley::Chef::Cookbook::SyntaxCheck do
 
   describe "#validate_ruby_files" do
     it "asks #untested_ruby_files for a list of files and calls #validate_ruby_file on each" do
-      subject.stub(:validate_ruby_file).with(anything()).exactly(9).times { true }
-      expect(subject.validate_ruby_files).to be_true
+      allow(subject).to receive(:validate_ruby_file).with(anything()).exactly(9).times { true }
+      expect(subject.validate_ruby_files).to be_truthy
     end
 
     it "marks the successfully validated ruby files" do
-      subject.stub(:validated).with(anything()).exactly(9).times
-      expect(subject.validate_ruby_files).to be_true
+      allow(subject).to receive(:validated).with(anything()).exactly(9).times
+      expect(subject.validate_ruby_files).to be_truthy
     end
 
     it "returns false if any ruby file fails to validate" do
-      subject.stub(:validate_ruby_file).with(/\.rb$/) { false }
-      expect(subject.validate_ruby_files).to be_false
+      allow(subject).to receive(:validate_ruby_file).with(/\.rb$/) { false }
+      expect(subject.validate_ruby_files).to be_falsey
     end
   end
 
   describe "#validate_templates" do
     it "asks #untested_template_files for a list of erb files and calls #validate_template on each" do
-      subject.stub(:validate_template).with(anything()).exactly(9).times { true }
-      expect(subject.validate_templates).to be_true
+      allow(subject).to receive(:validate_template).with(anything()).exactly(9).times { true }
+      expect(subject.validate_templates).to be_truthy
     end
 
     it "marks the successfully validated erb files" do
-      subject.stub(:validated).with(anything()).exactly(9).times
-      expect(subject.validate_templates).to be_true
+      allow(subject).to receive(:validated).with(anything()).exactly(9).times
+      expect(subject.validate_templates).to be_truthy
     end
 
     it "returns false if any erb file fails to validate" do
-      subject.stub(:validate_template).with(/\.erb$/) { false }
-      expect(subject.validate_templates).to be_false
+      allow(subject).to receive(:validate_template).with(/\.erb$/) { false }
+      expect(subject.validate_templates).to be_falsey
     end
   end
 

--- a/spec/unit/ridley/chef/cookbook_spec.rb
+++ b/spec/unit/ridley/chef/cookbook_spec.rb
@@ -8,18 +8,18 @@ describe Ridley::Chef::Cookbook do
       let(:cookbook_path) { fixtures_path.join("example_cookbook") }
 
       it "returns an instance of Ridley::Chef::Cookbook" do
-        subject.from_path(cookbook_path).should be_a(described_class)
+        expect(subject.from_path(cookbook_path)).to be_a(described_class)
       end
 
       it "has a cookbook_name attribute set to the value of the 'name' attribute in the metadata" do
-        subject.from_path(cookbook_path).cookbook_name.should eql("example_cookbook")
+        expect(subject.from_path(cookbook_path).cookbook_name).to eql("example_cookbook")
       end
 
       context "given a path that does not contain a metadata file" do
         it "raises an IOError" do
-          lambda {
+          expect {
             subject.from_path(Dir.mktmpdir)
-          }.should raise_error(IOError)
+          }.to raise_error(IOError)
         end
       end
 
@@ -51,7 +51,7 @@ describe Ridley::Chef::Cookbook do
         end
 
         it "sets the name of the cookbook from the metadata.rb" do
-          subject.from_path(cookbook_path).cookbook_name.should eql("rspec_test")
+          expect(subject.from_path(cookbook_path).cookbook_name).to eql("rspec_test")
         end
       end
 
@@ -73,7 +73,7 @@ describe Ridley::Chef::Cookbook do
         end
 
         it "prefers the metadata.json" do
-          subject.from_path(cookbook_path).cookbook_name.should eql("json_metadata")
+          expect(subject.from_path(cookbook_path).cookbook_name).to eql("json_metadata")
         end
       end
     end
@@ -81,7 +81,7 @@ describe Ridley::Chef::Cookbook do
     describe "::checksum" do
       it "delegates to Ridley::Chef::Digester.md5_checksum_for_file" do
         path = fixtures_path.join("example_cookbook", "metadata.rb")
-        Ridley::Chef::Digester.should_receive(:md5_checksum_for_file).with(path)
+        expect(Ridley::Chef::Digester).to receive(:md5_checksum_for_file).with(path)
 
         subject.checksum(path)
       end
@@ -96,11 +96,11 @@ describe Ridley::Chef::Cookbook do
 
   describe "#checksums" do
     it "returns a Hash" do
-      subject.checksums.should be_a(Hash)
+      expect(subject.checksums).to be_a(Hash)
     end
 
     it "has a key value for every cookbook file" do
-      subject.checksums.should have(subject.send(:files).length).items
+      expect(subject.checksums.size).to eq(subject.send(:files).length)
     end
   end
 
@@ -118,10 +118,10 @@ describe Ridley::Chef::Cookbook do
     end
 
     it "compiles the raw metadata.rb into a metadata.json file in the path of the cookbook" do
-      expect(subject.compiled_metadata?).to be_false
+      expect(subject.compiled_metadata?).to be_falsey
       subject.compile_metadata
       subject.reload
-      expect(subject.compiled_metadata?).to be_true
+      expect(subject.compiled_metadata?).to be_truthy
       expect(subject.cookbook_name).to eql("rspec_test")
       expect(subject.version).to eql("1.2.3")
     end
@@ -132,7 +132,7 @@ describe Ridley::Chef::Cookbook do
 
       it "writes the compiled metadata to a metadata.json file at the given out path" do
         subject.compile_metadata(out_path)
-        expect(File.exist?(File.join(out_path, "metadata.json"))).to be_true
+        expect(File.exist?(File.join(out_path, "metadata.json"))).to be_truthy
       end
     end
   end
@@ -152,7 +152,10 @@ describe Ridley::Chef::Cookbook do
         end
       end
 
-      its(:compiled_metadata?) { should be_true }
+      describe '#compiled_metadata?' do
+        subject { super().compiled_metadata? }
+        it { is_expected.to be_truthy }
+      end
     end
 
     context "when a metadata.json file is not present" do
@@ -164,7 +167,10 @@ describe Ridley::Chef::Cookbook do
         end
       end
 
-      its(:compiled_metadata?) { should be_false }
+      describe '#compiled_metadata?' do
+        subject { super().compiled_metadata? }
+        it { is_expected.to be_falsey }
+      end
     end
   end
 
@@ -181,7 +187,7 @@ describe Ridley::Chef::Cookbook do
         :providers,
         :root_files
       ].each do |category|
-        subject.manifest.should have_key(category)
+        expect(subject.manifest).to have_key(category)
       end
     end
   end
@@ -190,31 +196,31 @@ describe Ridley::Chef::Cookbook do
     let(:syntax_checker) { double('syntax_checker') }
 
     before(:each) do
-      subject.stub(:syntax_checker) { syntax_checker }
+      allow(subject).to receive(:syntax_checker) { syntax_checker }
     end
 
     it "asks the syntax_checker to validate the ruby and template files of the cookbook" do
-      syntax_checker.should_receive(:validate_ruby_files).and_return(true)
-      syntax_checker.should_receive(:validate_templates).and_return(true)
+      expect(syntax_checker).to receive(:validate_ruby_files).and_return(true)
+      expect(syntax_checker).to receive(:validate_templates).and_return(true)
 
       subject.validate
     end
 
     it "raises CookbookSyntaxError if the cookbook contains invalid ruby files" do
-      syntax_checker.should_receive(:validate_ruby_files).and_return(false)
+      expect(syntax_checker).to receive(:validate_ruby_files).and_return(false)
 
-      lambda {
+      expect {
         subject.validate
-      }.should raise_error(Ridley::Errors::CookbookSyntaxError)
+      }.to raise_error(Ridley::Errors::CookbookSyntaxError)
     end
 
     it "raises CookbookSyntaxError if the cookbook contains invalid template files" do
-      syntax_checker.should_receive(:validate_ruby_files).and_return(true)
-      syntax_checker.should_receive(:validate_templates).and_return(false)
+      expect(syntax_checker).to receive(:validate_ruby_files).and_return(true)
+      expect(syntax_checker).to receive(:validate_templates).and_return(false)
 
-      lambda {
+      expect {
         subject.validate
-      }.should raise_error(Ridley::Errors::CookbookSyntaxError)
+      }.to raise_error(Ridley::Errors::CookbookSyntaxError)
     end
   end
 
@@ -223,23 +229,23 @@ describe Ridley::Chef::Cookbook do
     before(:each) { @metadata = subject.file_metadata(:file, file) }
 
     it "has a :path key whose value is a relative path from the CachedCookbook's path" do
-      @metadata.should have_key(:path)
-      @metadata[:path].should be_relative_path
-      @metadata[:path].should eql("files/default/file.h")
+      expect(@metadata).to have_key(:path)
+      expect(@metadata[:path]).to be_relative_path
+      expect(@metadata[:path]).to eql("files/default/file.h")
     end
 
     it "has a :name key whose value is the basename of the target file" do
-      @metadata.should have_key(:name)
-      @metadata[:name].should eql("file.h")
+      expect(@metadata).to have_key(:name)
+      expect(@metadata[:name]).to eql("file.h")
     end
 
     it "has a :checksum key whose value is the checksum of the target file" do
-      @metadata.should have_key(:checksum)
-      @metadata[:checksum].should eql("7b1ebd2ff580ca9dc46fb27ec1653bf2")
+      expect(@metadata).to have_key(:checksum)
+      expect(@metadata[:checksum]).to eql("7b1ebd2ff580ca9dc46fb27ec1653bf2")
     end
 
     it "has a :specificity key" do
-      @metadata.should have_key(:specificity)
+      expect(@metadata).to have_key(:specificity)
     end
 
     context "given a file or template in a 'default' directory" do
@@ -247,7 +253,7 @@ describe Ridley::Chef::Cookbook do
       before(:each) { @metadata = subject.file_metadata(:files, file) }
 
       it "has a specificity of 'default'" do
-        @metadata[:specificity].should eql("default")
+        expect(@metadata[:specificity]).to eql("default")
       end
     end
 
@@ -256,7 +262,7 @@ describe Ridley::Chef::Cookbook do
       before(:each) { @metadata = subject.file_metadata(:files, file) }
 
       it "has a specificity of 'ubuntu'" do
-        @metadata[:specificity].should eql("ubuntu")
+        expect(@metadata[:specificity]).to eql("ubuntu")
       end
     end
   end
@@ -271,7 +277,7 @@ describe Ridley::Chef::Cookbook do
       let(:category) { :recipes }
 
       it "has a specificity of 'default'" do
-        @specificity.should eql("default")
+        expect(@specificity).to eql("default")
       end
     end
 
@@ -279,7 +285,7 @@ describe Ridley::Chef::Cookbook do
       let(:relpath) { 'default/config.erb' }
 
       it "has a specificity of 'default'" do
-        @specificity.should eql("default")
+        expect(@specificity).to eql("default")
       end
     end
 
@@ -287,7 +293,7 @@ describe Ridley::Chef::Cookbook do
       let(:relpath) { 'centos/config.erb' }
 
       it "has a specificity of 'centos'" do
-        @specificity.should eql("centos")
+        expect(@specificity).to eql("centos")
       end
     end
 
@@ -295,7 +301,7 @@ describe Ridley::Chef::Cookbook do
       let(:relpath) { 'config.erb' }
 
       it "has a specificity of 'root_default'" do
-        @specificity.should eql("root_default")
+        expect(@specificity).to eql("root_default")
       end
     end
   end
@@ -304,255 +310,255 @@ describe Ridley::Chef::Cookbook do
     subject { cookbook.to_hash }
 
     it "has a :frozen? flag" do
-      subject.should have_key(:frozen?)
+      expect(subject).to have_key(:frozen?)
     end
 
     it "has a :recipes key with a value of an Array Hashes" do
-      subject.should have_key(:recipes)
-      subject[:recipes].should be_a(Array)
+      expect(subject).to have_key(:recipes)
+      expect(subject[:recipes]).to be_a(Array)
       subject[:recipes].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :recipes Array of Hashes" do
-      subject[:recipes].first.should have_key(:name)
+      expect(subject[:recipes].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :recipes Array of Hashes" do
-      subject[:recipes].first.should have_key(:path)
+      expect(subject[:recipes].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :recipes Array of Hashes" do
-      subject[:recipes].first.should have_key(:checksum)
+      expect(subject[:recipes].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :recipes Array of Hashes" do
-      subject[:recipes].first.should have_key(:specificity)
+      expect(subject[:recipes].first).to have_key(:specificity)
     end
 
     it "has a :definitions key with a value of an Array Hashes" do
-      subject.should have_key(:definitions)
-      subject[:definitions].should be_a(Array)
+      expect(subject).to have_key(:definitions)
+      expect(subject[:definitions]).to be_a(Array)
       subject[:definitions].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :definitions Array of Hashes" do
-      subject[:definitions].first.should have_key(:name)
+      expect(subject[:definitions].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :definitions Array of Hashes" do
-      subject[:definitions].first.should have_key(:path)
+      expect(subject[:definitions].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :definitions Array of Hashes" do
-      subject[:definitions].first.should have_key(:checksum)
+      expect(subject[:definitions].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :definitions Array of Hashes" do
-      subject[:definitions].first.should have_key(:specificity)
+      expect(subject[:definitions].first).to have_key(:specificity)
     end
 
     it "has a :libraries key with a value of an Array Hashes" do
-      subject.should have_key(:libraries)
-      subject[:libraries].should be_a(Array)
+      expect(subject).to have_key(:libraries)
+      expect(subject[:libraries]).to be_a(Array)
       subject[:libraries].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :libraries Array of Hashes" do
-      subject[:libraries].first.should have_key(:name)
+      expect(subject[:libraries].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :libraries Array of Hashes" do
-      subject[:libraries].first.should have_key(:path)
+      expect(subject[:libraries].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :libraries Array of Hashes" do
-      subject[:libraries].first.should have_key(:checksum)
+      expect(subject[:libraries].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :libraries Array of Hashes" do
-      subject[:libraries].first.should have_key(:specificity)
+      expect(subject[:libraries].first).to have_key(:specificity)
     end
 
     it "has a :attributes key with a value of an Array Hashes" do
-      subject.should have_key(:attributes)
-      subject[:attributes].should be_a(Array)
+      expect(subject).to have_key(:attributes)
+      expect(subject[:attributes]).to be_a(Array)
       subject[:attributes].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :attributes Array of Hashes" do
-      subject[:attributes].first.should have_key(:name)
+      expect(subject[:attributes].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :attributes Array of Hashes" do
-      subject[:attributes].first.should have_key(:path)
+      expect(subject[:attributes].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :attributes Array of Hashes" do
-      subject[:attributes].first.should have_key(:checksum)
+      expect(subject[:attributes].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :attributes Array of Hashes" do
-      subject[:attributes].first.should have_key(:specificity)
+      expect(subject[:attributes].first).to have_key(:specificity)
     end
 
     it "has a :files key with a value of an Array Hashes" do
-      subject.should have_key(:files)
-      subject[:files].should be_a(Array)
+      expect(subject).to have_key(:files)
+      expect(subject[:files]).to be_a(Array)
       subject[:files].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :files Array of Hashes" do
-      subject[:files].first.should have_key(:name)
+      expect(subject[:files].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :files Array of Hashes" do
-      subject[:files].first.should have_key(:path)
+      expect(subject[:files].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :files Array of Hashes" do
-      subject[:files].first.should have_key(:checksum)
+      expect(subject[:files].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :files Array of Hashes" do
-      subject[:files].first.should have_key(:specificity)
+      expect(subject[:files].first).to have_key(:specificity)
     end
 
     it "has a :templates key with a value of an Array Hashes" do
-      subject.should have_key(:templates)
-      subject[:templates].should be_a(Array)
+      expect(subject).to have_key(:templates)
+      expect(subject[:templates]).to be_a(Array)
       subject[:templates].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :templates Array of Hashes" do
-      subject[:templates].first.should have_key(:name)
+      expect(subject[:templates].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :templates Array of Hashes" do
-      subject[:templates].first.should have_key(:path)
+      expect(subject[:templates].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :templates Array of Hashes" do
-      subject[:templates].first.should have_key(:checksum)
+      expect(subject[:templates].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :templates Array of Hashes" do
-      subject[:templates].first.should have_key(:specificity)
+      expect(subject[:templates].first).to have_key(:specificity)
     end
 
     it "has a :resources key with a value of an Array Hashes" do
-      subject.should have_key(:resources)
-      subject[:resources].should be_a(Array)
+      expect(subject).to have_key(:resources)
+      expect(subject[:resources]).to be_a(Array)
       subject[:resources].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :resources Array of Hashes" do
-      subject[:resources].first.should have_key(:name)
+      expect(subject[:resources].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :resources Array of Hashes" do
-      subject[:resources].first.should have_key(:path)
+      expect(subject[:resources].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :resources Array of Hashes" do
-      subject[:resources].first.should have_key(:checksum)
+      expect(subject[:resources].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :resources Array of Hashes" do
-      subject[:resources].first.should have_key(:specificity)
+      expect(subject[:resources].first).to have_key(:specificity)
     end
 
     it "has a :providers key with a value of an Array Hashes" do
-      subject.should have_key(:providers)
-      subject[:providers].should be_a(Array)
+      expect(subject).to have_key(:providers)
+      expect(subject[:providers]).to be_a(Array)
       subject[:providers].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :providers Array of Hashes" do
-      subject[:providers].first.should have_key(:name)
+      expect(subject[:providers].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :providers Array of Hashes" do
-      subject[:providers].first.should have_key(:path)
+      expect(subject[:providers].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :providers Array of Hashes" do
-      subject[:providers].first.should have_key(:checksum)
+      expect(subject[:providers].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :providers Array of Hashes" do
-      subject[:providers].first.should have_key(:specificity)
+      expect(subject[:providers].first).to have_key(:specificity)
     end
 
     it "has a :root_files key with a value of an Array Hashes" do
-      subject.should have_key(:root_files)
-      subject[:root_files].should be_a(Array)
+      expect(subject).to have_key(:root_files)
+      expect(subject[:root_files]).to be_a(Array)
       subject[:root_files].each do |item|
-        item.should be_a(Hash)
+        expect(item).to be_a(Hash)
       end
     end
 
     it "has a :name key value pair in a Hash of the :root_files Array of Hashes" do
-      subject[:root_files].first.should have_key(:name)
+      expect(subject[:root_files].first).to have_key(:name)
     end
 
     it "has a :path key value pair in a Hash of the :root_files Array of Hashes" do
-      subject[:root_files].first.should have_key(:path)
+      expect(subject[:root_files].first).to have_key(:path)
     end
 
     it "has a :checksum key value pair in a Hash of the :root_files Array of Hashes" do
-      subject[:root_files].first.should have_key(:checksum)
+      expect(subject[:root_files].first).to have_key(:checksum)
     end
 
     it "has a :specificity key value pair in a Hash of the :root_files Array of Hashes" do
-      subject[:root_files].first.should have_key(:specificity)
+      expect(subject[:root_files].first).to have_key(:specificity)
     end
 
     it "has a :cookbook_name key with a String value" do
-      subject.should have_key(:cookbook_name)
-      subject[:cookbook_name].should be_a(String)
+      expect(subject).to have_key(:cookbook_name)
+      expect(subject[:cookbook_name]).to be_a(String)
     end
 
     it "has a :metadata key with a Hashie::Mash value" do
-      subject.should have_key(:metadata)
-      subject[:metadata].should be_a(Hashie::Mash)
+      expect(subject).to have_key(:metadata)
+      expect(subject[:metadata]).to be_a(Hashie::Mash)
     end
 
     it "has a :version key with a String value" do
-      subject.should have_key(:version)
-      subject[:version].should be_a(String)
+      expect(subject).to have_key(:version)
+      expect(subject[:version]).to be_a(String)
     end
 
     it "has a :name key with a String value" do
-      subject.should have_key(:name)
-      subject[:name].should be_a(String)
+      expect(subject).to have_key(:name)
+      expect(subject[:name]).to be_a(String)
     end
 
     it "has a value containing the cookbook name and version separated by a dash for :name" do
       name, version = subject[:name].split('-')
 
-      name.should eql(cookbook.cookbook_name)
-      version.should eql(cookbook.version)
+      expect(name).to eql(cookbook.cookbook_name)
+      expect(version).to eql(cookbook.version)
     end
 
     it "has a :chef_type key with Cookbook::CHEF_TYPE as the value" do
-      subject.should have_key(:chef_type)
-      subject[:chef_type].should eql(Ridley::Chef::Cookbook::CHEF_TYPE)
+      expect(subject).to have_key(:chef_type)
+      expect(subject[:chef_type]).to eql(Ridley::Chef::Cookbook::CHEF_TYPE)
     end
   end
 
@@ -562,12 +568,12 @@ describe Ridley::Chef::Cookbook do
     end
 
     it "has a 'json_class' key with Cookbook::CHEF_JSON_CLASS  as the value" do
-      @json.should have_json_path('json_class')
-      parse_json(@json)['json_class'].should eql(Ridley::Chef::Cookbook::CHEF_JSON_CLASS)
+      expect(@json).to have_json_path('json_class')
+      expect(parse_json(@json)['json_class']).to eql(Ridley::Chef::Cookbook::CHEF_JSON_CLASS)
     end
 
     it "has a 'frozen?' flag" do
-      @json.should have_json_path('frozen?')
+      expect(@json).to have_json_path('frozen?')
     end
   end
 end

--- a/spec/unit/ridley/chef/digester_spec.rb
+++ b/spec/unit/ridley/chef/digester_spec.rb
@@ -9,14 +9,14 @@ describe Ridley::Chef::Digester do
 
   describe "when computing checksums of cookbook files and templates" do
     it "proxies the class method checksum_for_file to the instance" do
-      @cache.should_receive(:checksum_for_file).with("a_file_or_a_fail")
+      expect(@cache).to receive(:checksum_for_file).with("a_file_or_a_fail")
       described_class.checksum_for_file("a_file_or_a_fail")
     end
 
     it "generates a checksum from a non-file IO object" do
       io = StringIO.new("riseofthemachines\nriseofthechefs\n")
       expected_md5 = '0e157ac1e2dd73191b76067fb6b4bceb'
-      @cache.generate_md5_checksum(io).should == expected_md5
+      expect(@cache.generate_md5_checksum(io)).to eq(expected_md5)
     end
   end
 end

--- a/spec/unit/ridley/chef_object_spec.rb
+++ b/spec/unit/ridley/chef_object_spec.rb
@@ -10,7 +10,7 @@ describe Ridley::ChefObject do
           name: "a name"
         }
 
-        subject.any_instance.should_receive(:mass_assign).with(new_attrs)
+        expect_any_instance_of(subject).to receive(:mass_assign).with(new_attrs)
         subject.new(resource, new_attrs)
       end
     end
@@ -19,7 +19,7 @@ describe Ridley::ChefObject do
       it "sets the chef_type attr on the class" do
         subject.set_chef_type("environment")
 
-        subject.chef_type.should eql("environment")
+        expect(subject.chef_type).to eql("environment")
       end
     end
 
@@ -27,7 +27,7 @@ describe Ridley::ChefObject do
       it "sets the chef_json_class attr on the class" do
         subject.set_chef_json_class("Chef::Environment")
 
-        subject.chef_json_class.should eql("Chef::Environment")
+        expect(subject.chef_json_class).to eql("Chef::Environment")
       end
     end
 
@@ -35,25 +35,25 @@ describe Ridley::ChefObject do
       it "sets the chef_id attribute on the class" do
         subject.set_chef_id(:environment)
 
-        subject.chef_id.should eql(:environment)
+        expect(subject.chef_id).to eql(:environment)
       end
     end
 
     describe "::chef_type" do
       it "returns the underscored name of the including class if nothing is set" do
-        subject.chef_type.should eql(subject.class.name.underscore)
+        expect(subject.chef_type).to eql(subject.class.name.underscore)
       end
     end
 
     describe "::chef_json_class" do
       it "returns the chef_json if nothing has been set" do
-        subject.chef_json_class.should be_nil
+        expect(subject.chef_json_class).to be_nil
       end
     end
 
     describe "::chef_id" do
       it "returns nil if nothing is set" do
-        subject.chef_id.should be_nil
+        expect(subject.chef_id).to be_nil
       end
     end
   end
@@ -64,12 +64,12 @@ describe Ridley::ChefObject do
 
   describe "#save" do
     context "when the object is valid" do
-      before(:each) { subject.stub(:valid?).and_return(true) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(true) }
 
       it "sends a create message to the implementing class" do
         updated = double('updated')
-        updated.stub(:_attributes_).and_return(Hash.new)
-        resource.should_receive(:create).with(subject).and_return(updated)
+        allow(updated).to receive(:_attributes_).and_return(Hash.new)
+        expect(resource).to receive(:create).with(subject).and_return(updated)
 
         subject.save
       end
@@ -77,10 +77,10 @@ describe Ridley::ChefObject do
       context "when there is an HTTPConflict" do
         it "sends the update message to self" do
           updated = double('updated')
-          updated.stub(:[]).and_return(Hash.new)
-          updated.stub(:_attributes_).and_return(Hash.new)
-          resource.should_receive(:create).and_raise(Ridley::Errors::HTTPConflict.new(updated))
-          subject.should_receive(:update).and_return(updated)
+          allow(updated).to receive(:[]).and_return(Hash.new)
+          allow(updated).to receive(:_attributes_).and_return(Hash.new)
+          expect(resource).to receive(:create).and_raise(Ridley::Errors::HTTPConflict.new(updated))
+          expect(subject).to receive(:update).and_return(updated)
 
           subject.save
         end
@@ -88,12 +88,12 @@ describe Ridley::ChefObject do
     end
 
     context "when the object is invalid" do
-      before(:each) { subject.stub(:valid?).and_return(false) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(false) }
 
       it "raises an InvalidResource error" do
-        lambda {
+        expect {
           subject.save
-        }.should raise_error(Ridley::Errors::InvalidResource)
+        }.to raise_error(Ridley::Errors::InvalidResource)
       end
     end
   end
@@ -102,31 +102,31 @@ describe Ridley::ChefObject do
     context "when the object is valid" do
       let(:updated) do
         updated = double('updated')
-        updated.stub(:[]).and_return(Hash.new)
-        updated.stub(:_attributes_).and_return(Hash.new)
+        allow(updated).to receive(:[]).and_return(Hash.new)
+        allow(updated).to receive(:_attributes_).and_return(Hash.new)
         updated
       end
 
-      before(:each) { subject.stub(:valid?).and_return(true) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(true) }
 
       it "sends an update message to the implementing class" do
-        resource.should_receive(:update).with(subject).and_return(updated)
+        expect(resource).to receive(:update).with(subject).and_return(updated)
         subject.update
       end
 
       it "returns true" do
-        resource.should_receive(:update).with(subject).and_return(updated)
-        subject.update.should eql(true)
+        expect(resource).to receive(:update).with(subject).and_return(updated)
+        expect(subject.update).to eql(true)
       end
     end
 
     context "when the object is invalid" do
-      before(:each) { subject.stub(:valid?).and_return(false) }
+      before(:each) { allow(subject).to receive(:valid?).and_return(false) }
 
       it "raises an InvalidResource error" do
-        lambda {
+        expect {
           subject.update
-        }.should raise_error(Ridley::Errors::InvalidResource)
+        }.to raise_error(Ridley::Errors::InvalidResource)
       end
     end
   end
@@ -134,10 +134,10 @@ describe Ridley::ChefObject do
   describe "#chef_id" do
     it "returns the value of the chef_id attribute" do
       subject.class.attribute(:name)
-      subject.class.stub(:chef_id) { :name }
+      allow(subject.class).to receive(:chef_id) { :name }
       subject.mass_assign(name: "reset")
 
-      subject.chef_id.should eql("reset")
+      expect(subject.chef_id).to eql("reset")
     end
   end
 
@@ -147,17 +147,17 @@ describe Ridley::ChefObject do
     before(:each) do
       subject.class.attribute(:one)
       subject.class.attribute(:two)
-      resource.stub(:find).with(subject).and_return(updated_subject)
+      allow(resource).to receive(:find).with(subject).and_return(updated_subject)
     end
 
     it "returns itself" do
-      subject.reload.should eql(subject)
+      expect(subject.reload).to eql(subject)
     end
 
     it "sets the attributes of self to equal those of the updated object" do
       subject.reload
 
-      subject.get_attribute(:one).should eql("val")
+      expect(subject.get_attribute(:one)).to eql("val")
     end
 
     it "does not include attributes not set by the updated object" do
@@ -188,7 +188,7 @@ describe Ridley::ChefObject do
       end
 
       it "is equal" do
-        one.should be_eql(two)
+        expect(one).to be_eql(two)
       end
     end
 
@@ -199,7 +199,7 @@ describe Ridley::ChefObject do
       end
 
       it "is not equal" do
-        one.should_not be_eql(two)
+        expect(one).not_to be_eql(two)
       end
     end
   end
@@ -227,7 +227,7 @@ describe Ridley::ChefObject do
       end
 
       it "returns only one unique element" do
-        nodes.uniq.should have(1).item
+        expect(nodes.uniq.size).to eq(1)
       end
     end
 
@@ -240,7 +240,7 @@ describe Ridley::ChefObject do
       end
 
       it "returns all of the elements" do
-        nodes.uniq.should have(2).item
+        expect(nodes.uniq.size).to eq(2)
       end
     end
   end

--- a/spec/unit/ridley/chef_objects/client_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/client_object_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe Ridley::ClientObject do
   describe "#to_json" do
-    pending
+    skip
   end
 
   describe "#regenerate_key" do
-    pending
+    skip
   end
 end

--- a/spec/unit/ridley/chef_objects/cookbook_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/cookbook_object_spec.rb
@@ -7,7 +7,7 @@ describe Ridley::CookbookObject do
 
   describe "#download" do
     it "downloads each file" do
-      subject.stub(:manifest) do
+      allow(subject).to receive(:manifest) do
         {
           resources: [],
           providers: [],
@@ -37,8 +37,8 @@ describe Ridley::CookbookObject do
         }
       end
 
-      subject.should_receive(:download_file).with(:recipes, "recipes/default.rb", anything)
-      subject.should_receive(:download_file).with(:files, "files/default/plugins/README", anything)
+      expect(subject).to receive(:download_file).with(:recipes, "recipes/default.rb", anything)
+      expect(subject).to receive(:download_file).with(:files, "files/default/plugins/README", anything)
 
       subject.download
     end
@@ -48,11 +48,11 @@ describe Ridley::CookbookObject do
     let(:destination) { tmp_path.join('fake.file').to_s }
 
     before(:each) do
-      subject.stub(:root_files) { [ { path: 'metadata.rb', url: "http://test.it/file" } ] }
+      allow(subject).to receive(:root_files) { [ { path: 'metadata.rb', url: "http://test.it/file" } ] }
     end
 
     it "downloads the file from the file's url" do
-      connection.should_receive(:stream).with("http://test.it/file", destination)
+      expect(connection).to receive(:stream).with("http://test.it/file", destination)
 
       subject.download_file(:root_file, "metadata.rb", destination)
     end
@@ -67,27 +67,27 @@ describe Ridley::CookbookObject do
 
     context "when the cookbook doesn't have the specified file" do
       before(:each) do
-        subject.stub(:root_files) { Array.new }
+        allow(subject).to receive(:root_files) { Array.new }
       end
 
       it "returns nil" do
-        subject.download_file(:root_file, "metadata.rb", destination).should be_nil
+        expect(subject.download_file(:root_file, "metadata.rb", destination)).to be_nil
       end
     end
   end
 
   describe "#manifest" do
     it "returns a Hash" do
-      subject.manifest.should be_a(Hash)
+      expect(subject.manifest).to be_a(Hash)
     end
 
     it "has a key for each item in FILE_TYPES" do
-      subject.manifest.keys.should =~ described_class::FILE_TYPES
+      expect(subject.manifest.keys).to match_array(described_class::FILE_TYPES)
     end
 
     it "contains an empty array for each key" do
-      subject.manifest.should each be_a(Array)
-      subject.manifest.values.should each be_empty
+      expect(subject.manifest).to each be_a(Array)
+      expect(subject.manifest.values).to each be_empty
     end
   end
 
@@ -95,7 +95,7 @@ describe Ridley::CookbookObject do
     it "returns the updated self" do
       other = subject.dup
       other.version = "1.2.3"
-      resource.should_receive(:find).with(subject, subject.version).and_return(other)
+      expect(resource).to receive(:find).with(subject, subject.version).and_return(other)
 
       expect(subject.reload).to eq(other)
     end

--- a/spec/unit/ridley/chef_objects/data_bag_item_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/data_bag_item_object_spec.rb
@@ -21,7 +21,7 @@ describe Ridley::DataBagItemObject do
       end
 
       it "returns a new object from attributes in the 'raw_data' field" do
-        subject.from_hash(response).attributes.should eql(response["raw_data"])
+        expect(subject.from_hash(response).attributes).to eql(response["raw_data"])
       end
     end
 
@@ -34,20 +34,20 @@ describe Ridley::DataBagItemObject do
       end
 
       it "returns a new object from the hash" do
-        subject.from_hash(response).attributes.should eql(response)
+        expect(subject.from_hash(response).attributes).to eql(response)
       end
     end
   end
 
   describe "#decrypt" do
     before(:each) do
-      resource.stub(encrypted_data_bag_secret: File.read(fixtures_path.join("encrypted_data_bag_secret").to_s))
+      allow(resource).to receive_messages(encrypted_data_bag_secret: File.read(fixtures_path.join("encrypted_data_bag_secret").to_s))
     end
 
     it "decrypts an encrypted v0 value" do
       subject.attributes[:test] = "Xk0E8lV9r4BhZzcg4wal0X4w9ZexN3azxMjZ9r1MCZc="
       subject.decrypt
-      subject.attributes[:test][:database][:username].should == "test"
+      expect(subject.attributes[:test][:database][:username]).to eq("test")
     end
 
     it "decrypts an encrypted v1 value" do
@@ -57,21 +57,21 @@ describe Ridley::DataBagItemObject do
       subject.attributes[:password][:encrypted_data] = "zG+tTjtwOWA4vEYDoUwPYreXLZ1pFyKoWDGezEejmKs="
       subject.attributes[:password][:iv] = "URVhHxv/ZrnABJBvl82qsg=="
       subject.decrypt
-      subject.attributes[:password].should == "password123"
+      expect(subject.attributes[:password]).to eq("password123")
     end
 
     it "does not decrypt the id field" do
       id = "dbi_id"
       subject.attributes[:id] = id
       subject.decrypt
-      subject.attributes[:id].should == id
+      expect(subject.attributes[:id]).to eq(id)
     end
   end
 
   describe "#decrypt_value" do
     context "when no encrypted_data_bag_secret has been configured" do
       before do
-        resource.stub(encrypted_data_bag_secret: nil)
+        allow(resource).to receive_messages(encrypted_data_bag_secret: nil)
       end
 
       it "raises an EncryptedDataBagSecretNotSet error" do

--- a/spec/unit/ridley/chef_objects/data_bag_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/data_bag_object_spec.rb
@@ -5,5 +5,8 @@ describe Ridley::DataBagObject do
   let(:resource) { double('db-resource', item_resource: item_resource) }
   subject { described_class.new(resource) }
 
-  its(:item) { should be_a(Ridley::DataBagObject::DataBagItemProxy) }
+  describe '#item' do
+    subject { super().item }
+    it { is_expected.to be_a(Ridley::DataBagObject::DataBagItemProxy) }
+  end
 end

--- a/spec/unit/ridley/chef_objects/environment_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/environment_object_spec.rb
@@ -7,10 +7,10 @@ describe Ridley::EnvironmentObject do
     it "sets an override node attribute at the nested path" do
       subject.set_override_attribute('deep.nested.item', true)
 
-      subject.override_attributes.should have_key("deep")
-      subject.override_attributes["deep"].should have_key("nested")
-      subject.override_attributes["deep"]["nested"].should have_key("item")
-      subject.override_attributes["deep"]["nested"]["item"].should be_true
+      expect(subject.override_attributes).to have_key("deep")
+      expect(subject.override_attributes["deep"]).to have_key("nested")
+      expect(subject.override_attributes["deep"]["nested"]).to have_key("item")
+      expect(subject.override_attributes["deep"]["nested"]["item"]).to be_truthy
     end
 
     context "when the override attribute is already set" do
@@ -24,7 +24,7 @@ describe Ridley::EnvironmentObject do
         }
         subject.set_override_attribute('deep.nested.item', true)
 
-        subject.override_attributes["deep"]["nested"]["item"].should be_true
+        expect(subject.override_attributes["deep"]["nested"]["item"]).to be_truthy
       end
     end
   end
@@ -33,10 +33,10 @@ describe Ridley::EnvironmentObject do
     it "sets an override node attribute at the nested path" do
       subject.set_default_attribute('deep.nested.item', true)
 
-      subject.default_attributes.should have_key("deep")
-      subject.default_attributes["deep"].should have_key("nested")
-      subject.default_attributes["deep"]["nested"].should have_key("item")
-      subject.default_attributes["deep"]["nested"]["item"].should be_true
+      expect(subject.default_attributes).to have_key("deep")
+      expect(subject.default_attributes["deep"]).to have_key("nested")
+      expect(subject.default_attributes["deep"]["nested"]).to have_key("item")
+      expect(subject.default_attributes["deep"]["nested"]["item"]).to be_truthy
     end
 
     context "when the override attribute is already set" do
@@ -50,7 +50,7 @@ describe Ridley::EnvironmentObject do
         }
         subject.set_default_attribute('deep.nested.item', true)
 
-        subject.default_attributes["deep"]["nested"]["item"].should be_true
+        expect(subject.default_attributes["deep"]["nested"]["item"]).to be_truthy
       end
     end
 

--- a/spec/unit/ridley/chef_objects/node_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/node_object_spec.rb
@@ -58,10 +58,10 @@ describe Ridley::NodeObject do
     it "sets a normal node attribute at the nested path" do
        subject.set_chef_attribute('deep.nested.item', true)
 
-       subject.normal.should have_key("deep")
-       subject.normal["deep"].should have_key("nested")
-       subject.normal["deep"]["nested"].should have_key("item")
-       subject.normal["deep"]["nested"]["item"].should be_true
+       expect(subject.normal).to have_key("deep")
+       expect(subject.normal["deep"]).to have_key("nested")
+       expect(subject.normal["deep"]["nested"]).to have_key("item")
+       expect(subject.normal["deep"]["nested"]["item"]).to be_truthy
     end
 
     context "when the normal attribute is already set" do
@@ -75,7 +75,7 @@ describe Ridley::NodeObject do
         }
         subject.set_chef_attribute('deep.nested.item', true)
 
-        subject.normal["deep"]["nested"]["item"].should be_true
+        expect(subject.normal["deep"]["nested"]["item"]).to be_truthy
       end
     end
   end
@@ -123,13 +123,13 @@ describe Ridley::NodeObject do
         "cloud" => Hash.new
       }
 
-      subject.cloud?.should be_true
+      expect(subject.cloud?).to be_truthy
     end
 
     it "returns false if the cloud automatic attribute is not set" do
       subject.automatic.delete(:cloud)
 
-      subject.cloud?.should be_false
+      expect(subject.cloud?).to be_falsey
     end
   end
 
@@ -141,13 +141,13 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.eucalyptus?.should be_true
+      expect(subject.eucalyptus?).to be_truthy
     end
 
     it "returns false if the node is not a cloud node" do
       subject.automatic.delete(:cloud)
 
-      subject.eucalyptus?.should be_false
+      expect(subject.eucalyptus?).to be_falsey
     end
 
     it "returns false if the node is a cloud node but not using the eucalyptus provider" do
@@ -157,7 +157,7 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.eucalyptus?.should be_false
+      expect(subject.eucalyptus?).to be_falsey
     end
   end
 
@@ -169,13 +169,13 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.ec2?.should be_true
+      expect(subject.ec2?).to be_truthy
     end
 
     it "returns false if the node is not a cloud node" do
       subject.automatic.delete(:cloud)
 
-      subject.ec2?.should be_false
+      expect(subject.ec2?).to be_falsey
     end
 
     it "returns false if the node is a cloud node but not using the ec2 provider" do
@@ -185,7 +185,7 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.ec2?.should be_false
+      expect(subject.ec2?).to be_falsey
     end
   end
 
@@ -197,13 +197,13 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.rackspace?.should be_true
+      expect(subject.rackspace?).to be_truthy
     end
 
     it "returns false if the node is not a cloud node" do
       subject.automatic.delete(:cloud)
 
-      subject.rackspace?.should be_false
+      expect(subject.rackspace?).to be_falsey
     end
 
     it "returns false if the node is a cloud node but not using the rackspace provider" do
@@ -213,7 +213,7 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.rackspace?.should be_false
+      expect(subject.rackspace?).to be_falsey
     end
   end
 
@@ -225,13 +225,13 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.cloud_provider.should eql("ec2")
+      expect(subject.cloud_provider).to eql("ec2")
     end
 
     it "returns nil if the node is not a cloud node" do
       subject.automatic.delete(:cloud)
 
-      subject.cloud_provider.should be_nil
+      expect(subject.cloud_provider).to be_nil
     end
   end
 
@@ -244,7 +244,7 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.public_ipv4.should eql("10.0.0.1")
+      expect(subject.public_ipv4).to eql("10.0.0.1")
     end
 
     it "returns the ipaddress if the node is not a cloud node" do
@@ -253,7 +253,7 @@ describe Ridley::NodeObject do
       }
       subject.automatic.delete(:cloud)
 
-      subject.public_ipv4.should eql("192.168.1.1")
+      expect(subject.public_ipv4).to eql("192.168.1.1")
     end
   end
 
@@ -265,7 +265,7 @@ describe Ridley::NodeObject do
         }
       }
 
-      subject.public_hostname.should eql("reset.cloud.riotgames.com")
+      expect(subject.public_hostname).to eql("reset.cloud.riotgames.com")
     end
 
     it "returns the FQDN if the node is not a cloud node" do
@@ -274,7 +274,7 @@ describe Ridley::NodeObject do
       }
       subject.automatic.delete(:cloud)
 
-      subject.public_hostname.should eql("reset.internal.riotgames.com")
+      expect(subject.public_hostname).to eql("reset.internal.riotgames.com")
     end
   end
 
@@ -284,14 +284,14 @@ describe Ridley::NodeObject do
     it "appends items to the run_list" do
       subject.merge_data(run_list: ["cook::one", "cook::two"])
 
-      subject.run_list.should =~ ["cook::one", "cook::two"]
+      expect(subject.run_list).to match_array(["cook::one", "cook::two"])
     end
 
     it "ensures the run_list is unique if identical items are given" do
       subject.run_list = [ "cook::one" ]
       subject.merge_data(run_list: ["cook::one", "cook::two"])
 
-      subject.run_list.should =~ ["cook::one", "cook::two"]
+      expect(subject.run_list).to match_array(["cook::one", "cook::two"])
     end
 
     it "deep merges attributes into the normal attributes" do
@@ -310,10 +310,10 @@ describe Ridley::NodeObject do
         }
       })
 
-      subject.normal[:one][:two].should have_key(:four)
-      subject.normal[:one][:two][:four].should eql(:deep)
-      subject.normal[:one][:two].should have_key(:three)
-      subject.normal[:one][:two][:three].should eql(:deep)
+      expect(subject.normal[:one][:two]).to have_key(:four)
+      expect(subject.normal[:one][:two][:four]).to eql(:deep)
+      expect(subject.normal[:one][:two]).to have_key(:three)
+      expect(subject.normal[:one][:two][:three]).to eql(:deep)
     end
   end
 end

--- a/spec/unit/ridley/chef_objects/role_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/role_object_spec.rb
@@ -7,10 +7,10 @@ describe Ridley::RoleObject do
     it "sets an override node attribute at the nested path" do
        subject.set_override_attribute('deep.nested.item', true)
 
-       subject.override_attributes.should have_key("deep")
-       subject.override_attributes["deep"].should have_key("nested")
-       subject.override_attributes["deep"]["nested"].should have_key("item")
-       subject.override_attributes["deep"]["nested"]["item"].should be_true
+       expect(subject.override_attributes).to have_key("deep")
+       expect(subject.override_attributes["deep"]).to have_key("nested")
+       expect(subject.override_attributes["deep"]["nested"]).to have_key("item")
+       expect(subject.override_attributes["deep"]["nested"]["item"]).to be_truthy
     end
 
     context "when the override attribute is already set" do
@@ -24,7 +24,7 @@ describe Ridley::RoleObject do
         }
         subject.set_override_attribute('deep.nested.item', true)
 
-        subject.override_attributes["deep"]["nested"]["item"].should be_true
+        expect(subject.override_attributes["deep"]["nested"]["item"]).to be_truthy
       end
     end
   end
@@ -33,10 +33,10 @@ describe Ridley::RoleObject do
     it "sets an override node attribute at the nested path" do
        subject.set_default_attribute('deep.nested.item', true)
 
-       subject.default_attributes.should have_key("deep")
-       subject.default_attributes["deep"].should have_key("nested")
-       subject.default_attributes["deep"]["nested"].should have_key("item")
-       subject.default_attributes["deep"]["nested"]["item"].should be_true
+       expect(subject.default_attributes).to have_key("deep")
+       expect(subject.default_attributes["deep"]).to have_key("nested")
+       expect(subject.default_attributes["deep"]["nested"]).to have_key("item")
+       expect(subject.default_attributes["deep"]["nested"]["item"]).to be_truthy
     end
 
     context "when the override attribute is already set" do
@@ -50,7 +50,7 @@ describe Ridley::RoleObject do
         }
         subject.set_default_attribute('deep.nested.item', true)
 
-        subject.default_attributes["deep"]["nested"]["item"].should be_true
+        expect(subject.default_attributes["deep"]["nested"]["item"]).to be_truthy
       end
     end
   end

--- a/spec/unit/ridley/chef_objects/sandbox_object_spec.rb
+++ b/spec/unit/ridley/chef_objects/sandbox_object_spec.rb
@@ -24,15 +24,15 @@ describe Ridley::SandboxObject do
     )
   end
 
-  before { subject.stub(resource: resource) }
+  before { allow(subject).to receive_messages(resource: resource) }
 
   describe "#checksums" do
-    pending
+    skip
   end
 
   describe "#commit" do
     let(:response) { { is_completed: nil} }
-    before { resource.should_receive(:commit).with(subject).and_return(response) }
+    before { expect(resource).to receive(:commit).with(subject).and_return(response) }
 
     context "when the commit is successful" do
       before { response[:is_completed] = true }
@@ -40,7 +40,7 @@ describe Ridley::SandboxObject do
       it "has an 'is_completed' value of true" do
         subject.commit
 
-        subject.is_completed.should be_true
+        expect(subject.is_completed).to be_truthy
       end
     end
 
@@ -50,7 +50,7 @@ describe Ridley::SandboxObject do
       it "has an 'is_completed' value of false" do
         subject.commit
 
-        subject.is_completed.should be_false
+        expect(subject.is_completed).to be_falsey
       end
     end
   end
@@ -58,7 +58,7 @@ describe Ridley::SandboxObject do
   describe "#upload" do
     it "delegates to resource#upload" do
       checksums = double('checksums')
-      resource.should_receive(:upload).with(subject, checksums)
+      expect(resource).to receive(:upload).with(subject, checksums)
 
       subject.upload(checksums)
     end

--- a/spec/unit/ridley/client_spec.rb
+++ b/spec/unit/ridley/client_spec.rb
@@ -32,9 +32,20 @@ describe Ridley::Client do
       subject { described_class.new(options) }
 
       describe "parsing the 'server_url' option" do
-        its(:host) { should eql("api.opscode.com") }
-        its(:scheme) { should eql("https") }
-        its(:path_prefix) { should eql("/") }
+        describe '#host' do
+          subject { super().host }
+          it { is_expected.to eql("api.opscode.com") }
+        end
+
+        describe '#scheme' do
+          subject { super().scheme }
+          it { is_expected.to eql("https") }
+        end
+
+        describe '#path_prefix' do
+          subject { super().path_prefix }
+          it { is_expected.to eql("/") }
+        end
       end
 
       describe "with a server_url containing an organization" do
@@ -43,16 +54,16 @@ describe Ridley::Client do
         end
 
         it "gets the host data from the server_url" do
-          subject.host.should eql("api.opscode.com")
-          subject.scheme.should eql("https")
+          expect(subject.host).to eql("api.opscode.com")
+          expect(subject.scheme).to eql("https")
         end
 
         it "takes the organization out of the server_url and assigns it to the organization reader" do
-          subject.organization.should eql(organization)
+          expect(subject.organization).to eql(organization)
         end
 
         it "sets the 'path_prefix' of the connection the organization sub URI" do
-          subject.path_prefix.should eql("/organizations/#{organization}")
+          expect(subject.path_prefix).to eql("/organizations/#{organization}")
         end
       end
 
@@ -94,26 +105,26 @@ describe Ridley::Client do
       it "expands the path of the client_key" do
         config[:client_key] = "spec/fixtures/reset.pem"
 
-        described_class.new(config).client_key[0..4].should_not == "spec/"
+        expect(described_class.new(config).client_key[0..4]).not_to eq("spec/")
       end
 
       it "accepts a client key as a string" do
         key = File.read(fixtures_path.join("reset.pem").to_s)
         config[:client_key] = key.dup
-        described_class.new(config).client_key.should == key
+        expect(described_class.new(config).client_key).to eq(key)
       end
 
       it "assigns a 'chef_version' attribute from the given 'chef_version' option" do
-        described_class.new(config).chef_version.should eql("10.24.0-01")
+        expect(described_class.new(config).chef_version).to eql("10.24.0-01")
       end
     end
 
     describe "::open" do
       it "instantiates a new connection, yields to it, and terminates it" do
         new_instance = double(alive?: true)
-        described_class.should_receive(:new).and_return(new_instance)
-        new_instance.should_receive(:hello)
-        new_instance.should_receive(:terminate)
+        expect(described_class).to receive(:new).and_return(new_instance)
+        expect(new_instance).to receive(:hello)
+        expect(new_instance).to receive(:terminate)
 
         described_class.open do |f|
           f.hello
@@ -126,18 +137,45 @@ describe Ridley::Client do
 
   subject { instance }
 
-  its(:client) { should be_a(Ridley::ClientResource) }
-  its(:cookbook) { should be_a(Ridley::CookbookResource) }
-  its(:data_bag) { should be_a(Ridley::DataBagResource) }
-  its(:environment) { should be_a(Ridley::EnvironmentResource) }
-  its(:node) { should be_a(Ridley::NodeResource) }
-  its(:role) { should be_a(Ridley::RoleResource) }
-  its(:sandbox) { should be_a(Ridley::SandboxResource) }
+  describe '#client' do
+    subject { super().client }
+    it { is_expected.to be_a(Ridley::ClientResource) }
+  end
+
+  describe '#cookbook' do
+    subject { super().cookbook }
+    it { is_expected.to be_a(Ridley::CookbookResource) }
+  end
+
+  describe '#data_bag' do
+    subject { super().data_bag }
+    it { is_expected.to be_a(Ridley::DataBagResource) }
+  end
+
+  describe '#environment' do
+    subject { super().environment }
+    it { is_expected.to be_a(Ridley::EnvironmentResource) }
+  end
+
+  describe '#node' do
+    subject { super().node }
+    it { is_expected.to be_a(Ridley::NodeResource) }
+  end
+
+  describe '#role' do
+    subject { super().role }
+    it { is_expected.to be_a(Ridley::RoleResource) }
+  end
+
+  describe '#sandbox' do
+    subject { super().sandbox }
+    it { is_expected.to be_a(Ridley::SandboxResource) }
+  end
 
   describe "#encrypted_data_bag_secret" do
     subject { instance.encrypted_data_bag_secret }
 
-    it { should be_a(String) }
+    it { is_expected.to be_a(String) }
 
     context "when a encrypted_data_bag_secret_path is not provided" do
       before(:each) do

--- a/spec/unit/ridley/connection_spec.rb
+++ b/spec/unit/ridley/connection_spec.rb
@@ -18,7 +18,7 @@ describe Ridley::Connection do
       expect {
         subject.get('organizations/vialstudios')
       }.to raise_error
-      a_request(:get, "https://api.opscode.com/organizations/vialstudios").should have_been_made.times(6)
+      expect(a_request(:get, "https://api.opscode.com/organizations/vialstudios")).to have_been_made.times(6)
     end
 
     context "given a configured count of two (2) retries" do
@@ -31,7 +31,7 @@ describe Ridley::Connection do
           subject.get('organizations/vialstudios')
         }.to raise_error
 
-        a_request(:get, "https://api.opscode.com/organizations/vialstudios").should have_been_made.times(3)
+        expect(a_request(:get, "https://api.opscode.com/organizations/vialstudios")).to have_been_made.times(3)
       end
     end
   end
@@ -40,13 +40,13 @@ describe Ridley::Connection do
     it "returns :foss if the organization is not set" do
       subject.stub(:organization).and_return(nil)
 
-      subject.api_type.should eql(:foss)
+      expect(subject.api_type).to eql(:foss)
     end
 
     it "returns :hosted if the organization is set" do
       subject.stub(:organization).and_return("vialstudios")
 
-      subject.api_type.should eql(:hosted)
+      expect(subject.api_type).to eql(:hosted)
     end
   end
 
@@ -62,17 +62,17 @@ describe Ridley::Connection do
     it "creates a destination file on disk" do
       subject.stream(target, destination)
 
-      File.exist?(destination).should be_true
+      expect(File.exist?(destination)).to be_truthy
     end
 
     it "returns true when the file was copied" do
-      expect(subject.stream(target, destination)).to be_true
+      expect(subject.stream(target, destination)).to be_truthy
     end
 
     it "contains the contents of the response body" do
       subject.stream(target, destination)
 
-      File.read(destination).should include(contents)
+      expect(File.read(destination)).to include(contents)
     end
   end
 end

--- a/spec/unit/ridley/errors_spec.rb
+++ b/spec/unit/ridley/errors_spec.rb
@@ -18,7 +18,7 @@ describe Ridley::Errors do
         it "adds an item to the error map" do
           subject.register_error(400)
 
-          subject.error_map.should have(1).item
+          expect(subject.error_map.size).to eq(1)
         end
 
         it "adds a key of the given status code with a value of the class inheriting from HTTPError" do
@@ -26,7 +26,7 @@ describe Ridley::Errors do
             register_error(400)
           end
 
-          subject.error_map[400].should eql(RidleyTestHTTPError)
+          expect(subject.error_map[400]).to eql(RidleyTestHTTPError)
         end
       end
     end
@@ -35,7 +35,7 @@ describe Ridley::Errors do
       subject { Ridley::Errors::HTTPError.new(:body => "<html><body><h1>Redirected</h1></body></html>") }
 
       it "has an HTML body" do
-        subject.message.should eq("<html><body><h1>Redirected</h1></body></html>")
+        expect(subject.message).to eq("<html><body><h1>Redirected</h1></body></html>")
       end
     end
   end

--- a/spec/unit/ridley/middleware/chef_auth_spec.rb
+++ b/spec/unit/ridley/middleware/chef_auth_spec.rb
@@ -16,7 +16,7 @@ describe Ridley::Middleware::ChefAuth do
           host: "https://api.opscode.com",
           path: "/something.file"
         }
-        subject.authentication_headers(client_name, client_key, options).should be_a(Hash)
+        expect(subject.authentication_headers(client_name, client_key, options)).to be_a(Hash)
       end
 
       context "when the :client_key is an actual key" do
@@ -28,7 +28,7 @@ describe Ridley::Middleware::ChefAuth do
             host: "https://api.opscode.com",
             path: "/something.file"
           }
-          subject.authentication_headers(client_name, client_key, options).should be_a(Hash)
+          expect(subject.authentication_headers(client_name, client_key, options)).to be_a(Hash)
         end
       end
     end

--- a/spec/unit/ridley/middleware/chef_response_spec.rb
+++ b/spec/unit/ridley/middleware/chef_response_spec.rb
@@ -11,33 +11,33 @@ describe Ridley::Middleware::ChefResponse do
 
       it "returns true if response status between 200 and 210" do
         (200..210).each do |code|
-          env.should_receive(:[]).with(:status).and_return(code)
+          expect(env).to receive(:[]).with(:status).and_return(code)
 
-          subject.success?(env).should be_true
+          expect(subject.success?(env)).to be_truthy
         end
       end
 
       it "returns false if response status is in the 300 range" do
         (300..399).each do |code|
-          env.should_receive(:[]).with(:status).and_return(code)
+          expect(env).to receive(:[]).with(:status).and_return(code)
 
-          subject.success?(env).should be_false
+          expect(subject.success?(env)).to be_falsey
         end
       end
 
       it "returns false if response status is in the 400 range" do
         (400..499).each do |code|
-          env.should_receive(:[]).with(:status).and_return(code)
+          expect(env).to receive(:[]).with(:status).and_return(code)
 
-          subject.success?(env).should be_false
+          expect(subject.success?(env)).to be_falsey
         end
       end
 
       it "returns false if response status is in the 500 range" do
         (500..599).each do |code|
-          env.should_receive(:[]).with(:status).and_return(code)
+          expect(env).to receive(:[]).with(:status).and_return(code)
 
-          subject.success?(env).should be_false
+          expect(subject.success?(env)).to be_falsey
         end
       end
     end
@@ -117,15 +117,15 @@ describe Ridley::Middleware::ChefResponse do
     end
 
     it "raises a Ridley::Errors::HTTPBadRequest" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error(Ridley::Errors::HTTPBadRequest)
+      }.to raise_error(Ridley::Errors::HTTPBadRequest)
     end
 
     it "should have the body of the response as the error's message" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error("errors: '400 - Bad Request: Valid X-CHEF-VERSION header is required.'")
+      }.to raise_error("errors: '400 - Bad Request: Valid X-CHEF-VERSION header is required.'")
     end
   end
 
@@ -135,15 +135,15 @@ describe Ridley::Middleware::ChefResponse do
     end
 
     it "raises a Ridley::Errors::HTTPUnauthorized" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error(Ridley::Errors::HTTPUnauthorized)
+      }.to raise_error(Ridley::Errors::HTTPUnauthorized)
     end
 
     it "should have the body of the response as the error's message" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error("errors: '401 - Unauthorized.  You must properly authenticate your API requests!'")
+      }.to raise_error("errors: '401 - Unauthorized.  You must properly authenticate your API requests!'")
     end
   end
 
@@ -153,15 +153,15 @@ describe Ridley::Middleware::ChefResponse do
     end
 
     it "raises a Ridley::Errors::HTTPForbidden" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error(Ridley::Errors::HTTPForbidden)
+      }.to raise_error(Ridley::Errors::HTTPForbidden)
     end
 
     it "should have the body of the response as the error's message" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error("errors: '403 - Forbidden.'")
+      }.to raise_error("errors: '403 - Forbidden.'")
     end
   end
 
@@ -171,15 +171,15 @@ describe Ridley::Middleware::ChefResponse do
     end
 
     it "raises a Ridley::Errors::HTTPNotFound" do
-      lambda {
+      expect {
         subject.get('not_existant_route')
-      }.should raise_error(Ridley::Errors::HTTPNotFound)
+      }.to raise_error(Ridley::Errors::HTTPNotFound)
     end
 
     it "should have the body of the response as the error's message" do
-      lambda {
+      expect {
         subject.get('not_existant_route')
-      }.should raise_error(Ridley::Errors::HTTPNotFound, "errors: 'No routes match the request: /organizations/vialstudios/cookbookss/not_existant'")
+      }.to raise_error(Ridley::Errors::HTTPNotFound, "errors: 'No routes match the request: /organizations/vialstudios/cookbookss/not_existant'")
     end
   end
 
@@ -189,15 +189,15 @@ describe Ridley::Middleware::ChefResponse do
     end
 
     it "raises a Ridley::Errors::HTTPForbidden" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error(Ridley::Errors::HTTPConflict)
+      }.to raise_error(Ridley::Errors::HTTPConflict)
     end
 
     it "should have the body of the response as the error's message" do
-      lambda {
+      expect {
         subject.get('cookbooks')
-      }.should raise_error("errors: '409 - Conflict.'")
+      }.to raise_error("errors: '409 - Conflict.'")
     end
   end
 
@@ -207,7 +207,7 @@ describe Ridley::Middleware::ChefResponse do
     end
 
     it "returns a body containing a hash" do
-      subject.get('roles/reset').env[:body].should be_a(Hash)
+      expect(subject.get('roles/reset').env[:body]).to be_a(Hash)
     end
   end
 end

--- a/spec/unit/ridley/middleware/parse_json_spec.rb
+++ b/spec/unit/ridley/middleware/parse_json_spec.rb
@@ -9,42 +9,42 @@ describe Ridley::Middleware::ParseJson do
     describe "::response_type" do
       it "returns the first element of the response content-type" do
         env = double('env')
-        env.stub(:[]).with(:response_headers).and_return(
+        allow(env).to receive(:[]).with(:response_headers).and_return(
           'content-type' => 'text/html; charset=utf-8'
         )
 
-        subject.response_type(env).should eql("text/html")
+        expect(subject.response_type(env)).to eql("text/html")
       end
     end
 
     describe "::json_response?" do
       it "returns true if the value of content-type includes 'application/json' and the body looks like JSON" do
         env = double('env')
-        env.stub(:[]).with(:response_headers).and_return(
+        allow(env).to receive(:[]).with(:response_headers).and_return(
           'content-type' => 'application/json; charset=utf8'
         )
-        subject.should_receive(:looks_like_json?).with(env).and_return(true)
+        expect(subject).to receive(:looks_like_json?).with(env).and_return(true)
 
-        subject.json_response?(env).should be_true
+        expect(subject.json_response?(env)).to be_truthy
       end
 
       it "returns false if the value of content-type includes 'application/json' but the body does not look like JSON" do
         env = double('env')
-        env.stub(:[]).with(:response_headers).and_return(
+        allow(env).to receive(:[]).with(:response_headers).and_return(
           'content-type' => 'application/json; charset=utf8'
         )
-        subject.should_receive(:looks_like_json?).with(env).and_return(false)
+        expect(subject).to receive(:looks_like_json?).with(env).and_return(false)
 
-        subject.json_response?(env).should be_false
+        expect(subject.json_response?(env)).to be_falsey
       end
 
       it "returns false if the value of content-type does not include 'application/json'" do
         env = double('env')
-        env.stub(:[]).with(:response_headers).and_return(
+        allow(env).to receive(:[]).with(:response_headers).and_return(
           'content-type' => 'text/plain'
         )
 
-        subject.json_response?(env).should be_false
+        expect(subject.json_response?(env)).to be_falsey
       end
     end
 
@@ -52,15 +52,15 @@ describe Ridley::Middleware::ParseJson do
       let(:env) { double('env') }
 
       it "returns true if the given string contains JSON brackets" do
-        env.stub(:[]).with(:body).and_return("{\"name\":\"jamie\"}")
+        allow(env).to receive(:[]).with(:body).and_return("{\"name\":\"jamie\"}")
 
-        subject.looks_like_json?(env).should be_true
+        expect(subject.looks_like_json?(env)).to be_truthy
       end
 
       it "returns false if the given string does not contain JSON brackets" do
-        env.stub(:[]).with(:body).and_return("name")
+        allow(env).to receive(:[]).with(:body).and_return("name")
 
-        subject.looks_like_json?(env).should be_false
+        expect(subject.looks_like_json?(env)).to be_falsey
       end
     end
   end

--- a/spec/unit/ridley/mixins/from_file_spec.rb
+++ b/spec/unit/ridley/mixins/from_file_spec.rb
@@ -7,9 +7,9 @@ module Ridley
         let(:instance) { Class.new { include Ridley::Mixin::FromFile }.new }
 
         before do
-          File.stub(:exists?).and_return(true)
-          File.stub(:readable?).and_return(true)
-          IO.stub(:read).and_return('invalid Ruby code')
+          allow(File).to receive(:exists?).and_return(true)
+          allow(File).to receive(:readable?).and_return(true)
+          allow(IO).to receive(:read).and_return('invalid Ruby code')
         end
 
         it 'raises a FromFileParserError' do

--- a/spec/unit/ridley/resource_spec.rb
+++ b/spec/unit/ridley/resource_spec.rb
@@ -22,7 +22,7 @@ describe Ridley::Resource do
       it "sets the resource_path attr on the class" do
         subject.set_resource_path("environments")
 
-        subject.resource_path.should eql("environments")
+        expect(subject.resource_path).to eql("environments")
       end
     end
 
@@ -31,7 +31,7 @@ describe Ridley::Resource do
         before { subject.set_resource_path(nil) }
 
         it "returns the representation's chef type" do
-          subject.resource_path.should eql(representation.chef_type)
+          expect(subject.resource_path).to eql(representation.chef_type)
         end
       end
 
@@ -40,7 +40,7 @@ describe Ridley::Resource do
         before { subject.set_resource_path(set_path) }
 
         it "returns the set value" do
-          subject.resource_path.should eql(set_path)
+          expect(subject.resource_path).to eql(set_path)
         end
       end
     end
@@ -97,7 +97,7 @@ describe Ridley::Resource do
       end
 
       it "returns nil" do
-        subject.find(id).should be_nil
+        expect(subject.find(id)).to be_nil
       end
     end
   end
@@ -135,7 +135,7 @@ describe Ridley::Resource do
 
   describe "::delete_all" do
     it "sends a delete request for every object in the collection" do
-      pending
+      skip
     end
   end
 

--- a/spec/unit/ridley/resources/cookbook_resource_spec.rb
+++ b/spec/unit/ridley/resources/cookbook_resource_spec.rb
@@ -42,7 +42,7 @@ describe Ridley::CookbookResource do
       end
 
       it "returns the latest version" do
-        subject.latest_version(name).should eql("3.0.0")
+        expect(subject.latest_version(name)).to eql("3.0.0")
       end
     end
   end
@@ -58,16 +58,16 @@ describe Ridley::CookbookResource do
       end
 
       it "returns an array" do
-        subject.versions(name).should be_a(Array)
+        expect(subject.versions(name)).to be_a(Array)
       end
 
       it "contains a version string for each cookbook version available" do
         result = subject.versions(name)
 
-        result.should have(3).versions
-        result.should include("1.0.0")
-        result.should include("1.1.0")
-        result.should include("1.2.0")
+        expect(result.size).to eq(3)
+        expect(result).to include("1.0.0")
+        expect(result).to include("1.1.0")
+        expect(result).to include("1.2.0")
       end
     end
 
@@ -90,11 +90,11 @@ describe Ridley::CookbookResource do
       end
 
       it "returns a CookbookObject" do
-        subject.satisfy(name, ">= 2.0.0").should be_a(Ridley::CookbookObject)
+        expect(subject.satisfy(name, ">= 2.0.0")).to be_a(Ridley::CookbookObject)
       end
 
       it "is the best solution" do
-        subject.satisfy(name, ">= 2.0.0").version.should eql("3.0.0")
+        expect(subject.satisfy(name, ">= 2.0.0").version).to eql("3.0.0")
       end
     end
 
@@ -102,7 +102,7 @@ describe Ridley::CookbookResource do
       before { chef_cookbook(name, "1.0.0") }
 
       it "returns nil" do
-        subject.satisfy(name, ">= 2.0.0").should be_nil
+        expect(subject.satisfy(name, ">= 2.0.0")).to be_nil
       end
     end
 
@@ -148,6 +148,6 @@ describe Ridley::CookbookResource do
   end
 
   describe "#update" do
-    pending
+    skip
   end
 end

--- a/spec/unit/ridley/resources/data_bag_item_resource_spec.rb
+++ b/spec/unit/ridley/resources/data_bag_item_resource_spec.rb
@@ -3,5 +3,5 @@ require 'spec_helper'
 describe Ridley::DataBagItemResource do
   subject { described_class.new(double) }
 
-  pending
+  skip
 end

--- a/spec/unit/ridley/resources/data_bag_resource_spec.rb
+++ b/spec/unit/ridley/resources/data_bag_resource_spec.rb
@@ -8,13 +8,16 @@ describe Ridley::DataBagResource do
     subject { instance.item_resource }
 
     it "returns a DataBagItemResource" do
-      subject.should be_a(Ridley::DataBagItemResource)
+      expect(subject).to be_a(Ridley::DataBagItemResource)
     end
 
-    its(:encrypted_data_bag_secret) { should eql(secret) }
+    describe '#encrypted_data_bag_secret' do
+      subject { super().encrypted_data_bag_secret }
+      it { is_expected.to eql(secret) }
+    end
   end
 
   describe "#find" do
-    pending
+    skip
   end
 end

--- a/spec/unit/ridley/resources/environment_resource_spec.rb
+++ b/spec/unit/ridley/resources/environment_resource_spec.rb
@@ -28,13 +28,13 @@ describe Ridley::EnvironmentResource do
       end
 
       it "returns a Hash" do
-        should be_a(Hash)
+        is_expected.to be_a(Hash)
       end
 
       it "contains a key for each cookbook" do
-        subject.keys.should have(2).items
-        subject.should have_key("hello")
-        subject.should have_key("there")
+        expect(subject.keys.size).to eq(2)
+        expect(subject).to have_key("hello")
+        expect(subject).to have_key("there")
       end
     end
 

--- a/spec/unit/ridley/resources/role_resource_spec.rb
+++ b/spec/unit/ridley/resources/role_resource_spec.rb
@@ -3,5 +3,5 @@ require 'spec_helper'
 describe Ridley::RoleResource do
   subject { described_class.new(double) }
 
-  pending
+  skip
 end

--- a/spec/unit/ridley/resources/sandbox_resource_spec.rb
+++ b/spec/unit/ridley/resources/sandbox_resource_spec.rb
@@ -22,24 +22,24 @@ describe Ridley::SandboxResource do
     end
 
     it "returns a Ridley::SandboxObject" do
-      subject.create.should be_a(Ridley::SandboxObject)
+      expect(subject.create).to be_a(Ridley::SandboxObject)
     end
 
     it "has a value of 'false' for :is_completed" do
-      subject.create.is_completed.should be_false
+      expect(subject.create.is_completed).to be_falsey
     end
 
     it "has an empty Hash of checksums" do
-      subject.create.checksums.should be_a(Hash)
-      subject.create.checksums.should be_empty
+      expect(subject.create.checksums).to be_a(Hash)
+      expect(subject.create.checksums).to be_empty
     end
 
     it "has a value for :uri" do
-      subject.create.uri.should eql(sandbox_uri)
+      expect(subject.create.uri).to eql(sandbox_uri)
     end
 
     it "has a value for :sandbox_id" do
-      subject.create.sandbox_id.should eql(sandbox_id)
+      expect(subject.create.sandbox_id).to eql(sandbox_id)
     end
 
     context "when given an array of checksums" do
@@ -54,7 +54,7 @@ describe Ridley::SandboxResource do
       let(:checksum_array) { checksums.keys }
 
       it "has a Hash of checksums with each of the given checksum ids" do
-        subject.create(checksum_array).checksums.should have(checksum_array.length).checksums
+        expect(subject.create(checksum_array).checksums.size).to eq(checksum_array.length)
       end
     end
   end

--- a/spec/unit/ridley/resources/search_resource_spec.rb
+++ b/spec/unit/ridley/resources/search_resource_spec.rb
@@ -11,8 +11,8 @@ describe Ridley::SearchResource do
       it "contains a 'q' key/value" do
         result = subject.build_query(query_string, options)
 
-        result.should have_key(:q)
-        result[:q].should eql(query_string)
+        expect(result).to have_key(:q)
+        expect(result[:q]).to eql(query_string)
       end
 
       context "when :sort option is set" do
@@ -21,8 +21,8 @@ describe Ridley::SearchResource do
         it "contains a 'sort' key/value" do
           result = subject.build_query(query_string, options)
 
-          result.should have_key(:sort)
-          result[:sort].should eql("DESC")
+          expect(result).to have_key(:sort)
+          expect(result[:sort]).to eql("DESC")
         end
       end
 
@@ -32,8 +32,8 @@ describe Ridley::SearchResource do
         it "contains a 'start' key/value" do
           result = subject.build_query(query_string, options)
 
-          result.should have_key(:start)
-          result[:start].should eql(1)
+          expect(result).to have_key(:start)
+          expect(result[:start]).to eql(1)
         end
       end
 
@@ -43,8 +43,8 @@ describe Ridley::SearchResource do
         it "contains a 'rows' key/value" do
           result = subject.build_query(query_string, options)
 
-          result.should have_key(:rows)
-          result[:rows].should eql(1)
+          expect(result).to have_key(:rows)
+          expect(result[:rows]).to eql(1)
         end
       end
     end
@@ -89,7 +89,7 @@ describe Ridley::SearchResource do
 
     describe "::query_uri" do
       it "returns a URI path containing the search resource path and index" do
-        subject.query_uri(:nodes).should eql("search/nodes")
+        expect(subject.query_uri(:nodes)).to eql("search/nodes")
       end
     end
   end
@@ -118,7 +118,7 @@ describe Ridley::SearchResource do
     end
 
     it "contains a key for each index" do
-      subject.indexes.should have(4).items
+      expect(subject.indexes.size).to eq(4)
     end
   end
 
@@ -179,8 +179,8 @@ describe Ridley::SearchResource do
       it "returns an array of Ridley::NodeObject" do
         result = run
 
-        result.should be_a(Array)
-        result.should each be_a(Ridley::NodeObject)
+        expect(result).to be_a(Array)
+        expect(result).to each be_a(Ridley::NodeObject)
       end
 
       context "after the search has executed and results are returned" do
@@ -188,7 +188,7 @@ describe Ridley::SearchResource do
 
         it "Ridley::NodeObject instances contain the results" do
           first_result = search_results.first
-          first_result.name.should eq("ridley-one")
+          expect(first_result.name).to eq("ridley-one")
         end
       end
     end
@@ -217,8 +217,8 @@ describe Ridley::SearchResource do
       it "returns an array of Ridley::RoleObject" do
         result = run
 
-        result.should be_a(Array)
-        result.should each be_a(Ridley::RoleObject)
+        expect(result).to be_a(Array)
+        expect(result).to each be_a(Ridley::RoleObject)
       end
 
       context "after the search has executed and results are returned" do
@@ -226,7 +226,7 @@ describe Ridley::SearchResource do
 
         it "Ridley::RoleObject instances contain the results" do
           first_result = search_results.first
-          first_result.name.should eq("ridley-role-one")
+          expect(first_result.name).to eq("ridley-role-one")
         end
       end
     end
@@ -254,8 +254,8 @@ describe Ridley::SearchResource do
       it "returns an array of Ridley::EnvironmentObject" do
         result = run
 
-        result.should be_a(Array)
-        result.should each be_a(Ridley::EnvironmentObject)
+        expect(result).to be_a(Array)
+        expect(result).to each be_a(Ridley::EnvironmentObject)
       end
 
       context "after the search has executed and results are returned" do
@@ -263,7 +263,7 @@ describe Ridley::SearchResource do
 
         it "Ridley::EnvironmentObject instances contain the results" do
           first_result = search_results.first
-          first_result.name.should eq("ridley-env-test")
+          expect(first_result.name).to eq("ridley-env-test")
         end
       end
     end
@@ -292,8 +292,8 @@ describe Ridley::SearchResource do
       it "returns an array of Ridley::ClientObject" do
         result = run
 
-        result.should be_a(Array)
-        result.should each be_a(Ridley::ClientObject)
+        expect(result).to be_a(Array)
+        expect(result).to each be_a(Ridley::ClientObject)
       end
 
       context "after the search has executed and results are returned" do
@@ -301,7 +301,7 @@ describe Ridley::SearchResource do
 
         it "Ridley::ClientObject instances contain the results" do
           first_result = search_results.first
-          first_result.name.should eq("ridley-client-test")
+          expect(first_result.name).to eq("ridley-client-test")
         end
       end
     end

--- a/spec/unit/ridley/sandbox_uploader_spec.rb
+++ b/spec/unit/ridley/sandbox_uploader_spec.rb
@@ -8,14 +8,14 @@ describe Ridley::SandboxUploader do
       let(:io) { StringIO.new("some long string") }
       subject { described_class.checksum(io) }
 
-      it { should eq("2fb66bbfb88cdf9e07a3f1d1dfad71ab") }
+      it { is_expected.to eq("2fb66bbfb88cdf9e07a3f1d1dfad71ab") }
     end
 
     describe "::checksum64" do
       let(:io) { StringIO.new("some long string") }
       subject { described_class.checksum64(io) }
 
-      it { should eq("L7Zrv7iM354Ho/HR361xqw==") }
+      it { is_expected.to eq("L7Zrv7iM354Ho/HR361xqw==") }
     end
   end
 
@@ -80,7 +80,7 @@ describe Ridley::SandboxUploader do
       end
 
       it "returns nil" do
-        subject.upload(sandbox, chk_id, path).should be_nil
+        expect(subject.upload(sandbox, chk_id, path)).to be_nil
       end
     end
 

--- a/spec/unit/ridley_spec.rb
+++ b/spec/unit/ridley_spec.rb
@@ -9,9 +9,9 @@ describe Ridley do
     describe "::new" do
       it "creates a new Ridley::Connection" do
         client = double('client')
-        Ridley::Client.should_receive(:new).with(config).and_return(client)
+        expect(Ridley::Client).to receive(:new).with(config).and_return(client)
 
-        subject.new(config).should eql(client)
+        expect(subject.new(config)).to eql(client)
       end
     end
 
@@ -32,12 +32,12 @@ describe Ridley do
       let(:path) { tmp_path.join('config.rb').to_s }
 
       before do
-        Ridley::Client.stub(:new).and_return(client)
+        allow(Ridley::Client).to receive(:new).and_return(client)
         File.open(path, 'w') { |f| f.write(chef_config) }
       end
 
       it "creates a Ridley connection from the Chef config" do
-        Ridley::Client.should_receive(:new).with({
+        expect(Ridley::Client).to receive(:new).with({
           client_key: 'username.pem',
           client_name: 'username',
           validator_client: 'validator',
@@ -58,7 +58,7 @@ describe Ridley do
       end
 
       it "allows the user to override attributes" do
-        Ridley::Client.should_receive(:new).with({
+        expect(Ridley::Client).to receive(:new).with({
           client_key: 'bacon.pem',
           client_name: 'bacon',
           validator_client: 'validator',
@@ -88,7 +88,7 @@ describe Ridley do
         end
 
         it "does a knife.rb search" do
-          Ridley::Client.should_receive(:new).with({
+          expect(Ridley::Client).to receive(:new).with({
             client_key: 'username.pem',
             client_name: 'username',
             validator_client: 'validator',


### PR DESCRIPTION
I've converted specs to RSpec 3.0.4 syntax with Transpec then undid .stub() changes because for some strange reason with new syntax tests were failing. I don't understand why but original methods were called instead of stubbed ones. While for my own trivial object with #find and #regenerate_key everything was working fine. But as old syntax was working properly I decided to leave it for .stub().

Here is my question regarding this issue in debian's mail list: https://lists.debian.org/debian-ruby/2015/08/msg00008.html