### PR TITLE
Allow Hashie 3.x as well as 2.x

### DIFF
--- a/ridley.gemspec
+++ b/ridley.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid-io',            '~> 0.16.1'
   s.add_dependency 'erubis'
   s.add_dependency 'faraday',                 '~> 0.9.0'
-  s.add_dependency 'hashie',                  '>= 2.0.2', '< 3.0.0'
+  s.add_dependency 'hashie',                  '>= 2.0.2', '< 4.0.0'
   s.add_dependency 'httpclient',              '~> 2.6'
   s.add_dependency 'json',                    '>= 1.7.7'
   s.add_dependency 'mixlib-authentication',   '>= 1.3.0'


### PR DESCRIPTION
I'm seeing an issue where ChefSpec can blow up on a conflict over the hashie version, because ChefSpec will bring in Chef and Chef Zero via its gemspec, but there's no explicit dep on Berks. Eventually we need to provide some way to run ChefSpec with dependencies locked down, but this will fix the short-term issue for us.

cc @reset