### PR TITLE
allow recursive loading of cookbook libraries

### DIFF
--- a/lib/ridley/chef/cookbook.rb
+++ b/lib/ridley/chef/cookbook.rb
@@ -255,8 +255,8 @@ module Ridley::Chef
       def load_files
         load_shallow(:recipes, 'recipes', '*.rb')
         load_shallow(:definitions, 'definitions', '*.rb')
-        load_shallow(:libraries, 'libraries', '*.rb')
         load_shallow(:attributes, 'attributes', '*.rb')
+        load_recursively(:libraries, 'libraries', '*.rb')
         load_recursively(:files, "files", "*")
         load_recursively(:templates, "templates", "*")
         load_recursively(:resources, "resources", "*.rb")


### PR DESCRIPTION
We have a library cookbook that we organize a few shared components into folders. When trying to upload with berkshelf we found that those files were getting missed. Found that berkshelf was using [ridley](https://github.com/berkshelf/berkshelf/blob/master/lib/berkshelf/uploader.rb#L50-L72) to do their uploads. 

This change makes it so libraries are loaded recursively like what is done for templates and files. 


