### PR TITLE
Use chef-config for configuration

### DIFF
--- a/lib/ridley/chef/config.rb
+++ b/lib/ridley/chef/config.rb
@@ -1,86 +1,23 @@
-require 'buff/config/ruby'
+require 'chef-config/config'
+require 'chef-config/workstation_config_loader'
 require 'socket'
 
 module Ridley::Chef
-  class Config < Buff::Config::Ruby
-    class << self
-      # Return the most sensible path to the Chef configuration file. This can
-      # be configured by setting a value for the 'RIDLEY_CHEF_CONFIG' environment
-      # variable.
-      #
-      # @return [String, nil]
-      def location
-        possibles = []
-
-        possibles << ENV['RIDLEY_CHEF_CONFIG'] if ENV['RIDLEY_CHEF_CONFIG']
-        possibles << File.join(ENV['KNIFE_HOME'], 'knife.rb') if ENV['KNIFE_HOME']
-        possibles << File.join(working_dir, 'knife.rb') if working_dir
-
-        # Ascending search for .chef directory siblings
-        Pathname.new(working_dir).ascend do |file|
-          sibling_chef = File.join(file, '.chef')
-          possibles << File.join(sibling_chef, 'knife.rb')
-        end if working_dir
-
-        possibles << File.join(ENV['HOME'], '.chef', 'knife.rb') if ENV['HOME']
-        possibles.compact!
-
-        location = possibles.find { |loc| File.exists?(File.expand_path(loc)) }
-
-        File.expand_path(location) unless location.nil?
-      end
-
-      private
-
-        # The current working directory
-        #
-        # @return [String]
-        def working_dir
-          ENV['PWD'] || Dir.pwd
-        end
-    end
-
-    set_assignment_mode :carefree
-
-    attribute :node_name,
-      default: -> { Socket.gethostname }
-    attribute :chef_server_url,
-      default: 'http://localhost:4000'
-    attribute :client_key,
-      default: -> { platform_specific_path('/etc/chef/client.pem') }
-    attribute :validation_key,
-      default: -> { platform_specific_path('/etc/chef/validation.pem') }
-    attribute :validation_client_name,
-      default: 'chef-validator'
-
-    attribute :cookbook_copyright,
-      default: 'YOUR_NAME'
-    attribute :cookbook_email,
-      default: 'YOUR_EMAIL'
-    attribute :cookbook_license,
-      default: 'reserved'
-
-    attribute :knife,
-      default: {}
-
-    # Prior to Chef 11, the cache implementation was based on
-    # moneta and configured via cache_options[:path]. Knife configs
-    # generated with Chef 11 will have `syntax_check_cache_path`, but older
-    # configs will have `cache_options[:path]`. `cache_options` is marked
-    # deprecated in chef/config.rb but doesn't currently trigger a warning.
-    # See also: CHEF-3715
-    attribute :syntax_check_cache_path,
-      default: -> { Dir.mktmpdir }
-    attribute :cache_options,
-      default: -> { { path: defined?(syntax_check_cache_path) ? syntax_check_cache_path : Dir.mktmpdir } }
-
+  class Config
     # Create a new Chef Config object.
     #
     # @param [#to_s] path
     #   the path to the configuration file
     # @param [Hash] options
     def initialize(path, options = {})
-      super(path || self.class.location, options)
+      ChefConfig::WorkstationConfigLoader.new(path).load
+      ChefConfig::Config.merge!(options)
+      ChefConfig::Config.export_proxies # Set proxy settings as environment variables
+    end
+
+    # The configuration as a hash
+    def to_hash
+      ChefConfig::Config.save(true)
     end
   end
 end

--- a/ridley.gemspec
+++ b/ridley.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'buff-shell_out',          '~> 0.1'
   s.add_dependency 'celluloid',               '~> 0.16.0'
   s.add_dependency 'celluloid-io',            '~> 0.16.1'
+  s.add_dependency 'chef-config'
   s.add_dependency 'erubis'
   s.add_dependency 'faraday',                 '~> 0.9.0'
   s.add_dependency 'hashie',                  '>= 2.0.2', '< 4.0.0'

--- a/spec/unit/ridley_spec.rb
+++ b/spec/unit/ridley_spec.rb
@@ -37,43 +37,29 @@ describe Ridley do
       end
 
       it "creates a Ridley connection from the Chef config" do
-        expect(Ridley::Client).to receive(:new).with({
+        expect(Ridley::Client).to receive(:new).with(hash_including(
           client_key: 'username.pem',
           client_name: 'username',
           validator_client: 'validator',
           validator_path: 'validator.pem',
           server_url: 'https://api.opscode.com',
-
-          cookbook_copyright: 'YOUR_NAME',
-          cookbook_email: 'YOUR_EMAIL',
-          cookbook_license: 'reserved',
-
-          knife: {},
-
           syntax_check_cache_path: "/foo/bar",
           cache_options: { path: "~/.chef/checksums" },
-        }).and_return(nil)
+        )).and_return(nil)
 
         subject.from_chef_config(path)
       end
 
       it "allows the user to override attributes" do
-        expect(Ridley::Client).to receive(:new).with({
+        expect(Ridley::Client).to receive(:new).with(hash_including(
           client_key: 'bacon.pem',
           client_name: 'bacon',
           validator_client: 'validator',
           validator_path: 'validator.pem',
           server_url: 'https://api.opscode.com',
-
-          cookbook_copyright: 'YOUR_NAME',
-          cookbook_email: 'YOUR_EMAIL',
-          cookbook_license: 'reserved',
-
-          knife: {},
-
           syntax_check_cache_path: "/foo/bar",
           cache_options: { path: "~/.chef/checksums" },
-        })
+        ))
 
         subject.from_chef_config(path, client_key: 'bacon.pem', client_name: 'bacon')
       end
@@ -88,22 +74,15 @@ describe Ridley do
         end
 
         it "does a knife.rb search" do
-          expect(Ridley::Client).to receive(:new).with({
+          expect(Ridley::Client).to receive(:new).with(hash_including(
             client_key: 'username.pem',
             client_name: 'username',
             validator_client: 'validator',
             validator_path: 'validator.pem',
             server_url: 'https://api.opscode.com',
-
-            cookbook_copyright: 'YOUR_NAME',
-            cookbook_email: 'YOUR_EMAIL',
-            cookbook_license: 'reserved',
-
-            knife: {},
-
             syntax_check_cache_path: "/foo/bar",
             cache_options: { path: "~/.chef/checksums" },
-          }).and_return(nil)
+          )).and_return(nil)
 
           Dir.chdir(tmp_path) do
             ENV['PWD'] = Dir.pwd


### PR DESCRIPTION
Replace the inner workings of Ridley::Chef::Config to use
[ChefConfig](https://github.com/chef/chef/tree/master/chef-config),
which includes using it's logic for locating a config.rb or knife.rb and
its mechanism for setting proxy environment variables.